### PR TITLE
Refresh beta page with Edge of Fate dark theme

### DIFF
--- a/beta.css
+++ b/beta.css
@@ -1,0 +1,876 @@
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&display=swap');
+
+:root {
+  --bg: #04060f;
+  --bg-alt: #050718;
+  --panel: linear-gradient(150deg, rgba(17, 23, 41, 0.92) 0%, rgba(8, 12, 26, 0.96) 100%);
+  --panel-alt: rgba(11, 16, 32, 0.88);
+  --muted: #2a3352;
+  --muted2: #161d33;
+  --text: #edf1ff;
+  --sub: #8d98c7;
+  --accent: #a48dff;
+  --accent-soft: #63f5ff;
+  --accent-strong: #f48aff;
+  --gold: #f7d36f;
+  --border: rgba(92, 119, 194, 0.35);
+  --border-strong: rgba(164, 141, 255, 0.55);
+  --chip-border: rgba(115, 144, 220, 0.45);
+  --shadow: 0 25px 60px -35px rgba(8, 142, 255, 0.55);
+  --shadow-soft: 0 20px 60px -40px rgba(164, 141, 255, 0.6);
+  --gloss: linear-gradient(120deg, rgba(255, 255, 255, 0.08) 0%, transparent 65%);
+  --stat-red: #ff5b6e;
+  --stat-yellow: #ffe783;
+  --stat-green: #6dffb5;
+  --stat-blue: #61e4ff;
+  --row-alt-a: rgba(14, 20, 38, 0.75);
+  --row-alt-b: rgba(10, 16, 32, 0.75);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 15%, rgba(164, 141, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(99, 245, 255, 0.16), transparent 55%),
+    radial-gradient(circle at 50% 80%, rgba(74, 98, 255, 0.12), transparent 60%),
+    linear-gradient(180deg, var(--bg-alt) 0%, var(--bg) 60%, #02030b 100%);
+  color: var(--text);
+  font-family: 'Rajdhani', 'Inter', 'Segoe UI', 'Roboto', Arial, sans-serif;
+  letter-spacing: 0.01em;
+  color-scheme: dark;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -30vmax auto auto -20vmax;
+  width: 70vmax;
+  height: 70vmax;
+  background: radial-gradient(circle at center, rgba(164, 141, 255, 0.22) 0%, rgba(8, 12, 26, 0) 70%);
+  pointer-events: none;
+  filter: blur(8px);
+  opacity: 0.8;
+  z-index: 0;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: auto -30vmax -35vmax auto;
+  width: 65vmax;
+  height: 65vmax;
+  background: radial-gradient(circle at center, rgba(99, 245, 255, 0.18) 0%, rgba(8, 12, 26, 0) 70%);
+  pointer-events: none;
+  filter: blur(10px);
+  opacity: 0.7;
+  z-index: 0;
+}
+
+.wrap {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+  position: relative;
+  z-index: 1;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 46px);
+  letter-spacing: 0.03em;
+  font-weight: 700;
+}
+
+.title-prefix {
+  display: block;
+  text-transform: uppercase;
+  font-size: 13px;
+  letter-spacing: 0.55em;
+  color: var(--sub);
+  margin-bottom: 10px;
+}
+
+.title-main {
+  display: inline-block;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-soft) 50%, var(--accent-strong) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 16px 30px rgba(6, 10, 26, 0.75);
+}
+
+.tagline {
+  margin: 12px 0 22px;
+  font-size: 15px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-soft);
+}
+
+.muted {
+  color: var(--sub);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent-soft);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent);
+}
+
+.panel {
+  position: relative;
+  border-radius: 24px;
+  padding: 28px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--gloss);
+  opacity: 0.25;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.panel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(135deg, transparent 0 14px, rgba(255, 255, 255, 0.02) 14px 16px);
+  opacity: 0.2;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-panel {
+  margin-bottom: 28px;
+  padding: clamp(28px, 6vw, 42px);
+}
+
+.hero-panel::before {
+  content: '';
+  position: absolute;
+  inset: -120px -160px auto auto;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(164, 141, 255, 0.28), rgba(8, 12, 26, 0));
+  pointer-events: none;
+  filter: blur(8px);
+  opacity: 0.6;
+}
+
+.hero-panel::after {
+  content: '';
+  position: absolute;
+  inset: auto auto -140px -160px;
+  width: 460px;
+  height: 460px;
+  background: radial-gradient(circle at center, rgba(99, 245, 255, 0.22), rgba(8, 12, 26, 0));
+  pointer-events: none;
+  filter: blur(10px);
+  opacity: 0.55;
+}
+
+.hero-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 32px;
+}
+
+.hero-copy {
+  flex: 1 1 360px;
+  max-width: 640px;
+}
+
+.hero-hints {
+  display: grid;
+  gap: 10px;
+}
+
+.hero-hints .muted {
+  position: relative;
+  padding: 12px 14px 12px 20px;
+  border-radius: 12px;
+  border-left: 3px solid rgba(99, 245, 255, 0.5);
+  background: rgba(15, 22, 44, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.hero-hints .muted::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 16px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  box-shadow: 0 0 8px rgba(99, 245, 255, 0.8);
+}
+
+.toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.hero-actions {
+  flex: 0 1 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  border-radius: 18px;
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(165deg, rgba(20, 26, 50, 0.95), rgba(8, 12, 28, 0.85));
+  box-shadow: var(--shadow-soft);
+  align-self: flex-start;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-actions::before {
+  content: '';
+  position: absolute;
+  inset: -80px auto auto -80px;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle at center, rgba(164, 141, 255, 0.35), rgba(8, 12, 26, 0));
+  filter: blur(12px);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.hero-actions::after {
+  content: '';
+  position: absolute;
+  inset: auto -60px -120px auto;
+  width: 280px;
+  height: 280px;
+  background: radial-gradient(circle at center, rgba(99, 245, 255, 0.28), rgba(8, 12, 26, 0));
+  filter: blur(12px);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.hero-actions-title {
+  text-transform: uppercase;
+  letter-spacing: 0.38em;
+  font-size: 12px;
+  color: var(--accent-soft);
+}
+
+.hero-actions-sub {
+  margin: -6px 0 6px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-actions .btn {
+  width: 100%;
+}
+
+.filters-panel {
+  margin-bottom: 28px;
+  padding: 26px;
+}
+
+.filters-panel::before {
+  content: '';
+  position: absolute;
+  inset: -120px auto auto -140px;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle at center, rgba(99, 245, 255, 0.22), rgba(8, 12, 26, 0));
+  pointer-events: none;
+  filter: blur(10px);
+  opacity: 0.4;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+  text-transform: uppercase;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.42em;
+  color: var(--accent);
+}
+
+.section-heading::after {
+  content: '';
+  width: 72px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent) 0%, transparent 100%);
+}
+
+.section-sub {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--sub);
+}
+
+.filters {
+  display: grid;
+  gap: 16px;
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(12, 18, 36, 0.7);
+  border: 1px solid rgba(75, 92, 150, 0.32);
+}
+
+.label {
+  min-width: 84px;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.seg .chip {
+  border: 1px solid var(--chip-border);
+  background: rgba(8, 12, 26, 0.7);
+  color: var(--sub);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, color 0.2s ease, background 0.2s ease;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.seg .chip:hover {
+  border-color: rgba(99, 245, 255, 0.55);
+  color: var(--accent-soft);
+  transform: translateY(-1px);
+}
+
+.seg .chip:focus-visible {
+  outline: 2px solid rgba(99, 245, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.seg .chip.active {
+  background: linear-gradient(120deg, rgba(164, 141, 255, 0.45), rgba(99, 245, 255, 0.45));
+  color: #050712;
+  border-color: rgba(99, 245, 255, 0.8);
+  box-shadow: 0 12px 28px -18px rgba(99, 245, 255, 0.7);
+}
+
+.chip-icon {
+  display: inline-block;
+  filter: drop-shadow(0 0 4px rgba(99, 245, 255, 0.35));
+}
+
+.chip-icon.rarity {
+  filter: drop-shadow(0 0 4px rgba(244, 138, 255, 0.4));
+}
+
+.chip-icon-mask {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+  margin-right: 6px;
+  background-color: var(--accent-soft);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  transition: background-color 0.2s ease;
+}
+
+.seg .chip.active .chip-icon-mask {
+  background-color: #050712;
+}
+
+input,
+button {
+  font-family: 'Rajdhani', 'Inter', 'Segoe UI', sans-serif;
+}
+
+input[type="file"] {
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px dashed rgba(99, 245, 255, 0.35);
+  background: rgba(8, 12, 26, 0.75);
+  color: var(--sub);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+input[type="file"]:hover,
+input[type="file"]:focus-visible {
+  border-color: rgba(99, 245, 255, 0.6);
+  color: var(--accent-soft);
+  background: rgba(12, 18, 36, 0.92);
+  outline: none;
+}
+
+input[type="file"]::file-selector-button {
+  border: none;
+  background: linear-gradient(120deg, rgba(30, 40, 72, 0.85), rgba(48, 62, 106, 0.85));
+  color: var(--accent-soft);
+  padding: 8px 16px;
+  border-radius: 10px;
+  margin-right: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+
+input[type="file"]::file-selector-button:hover {
+  filter: brightness(1.2);
+  transform: translateY(-1px);
+}
+
+input[type="file"]::-webkit-file-upload-button {
+  border: none;
+  background: linear-gradient(120deg, rgba(30, 40, 72, 0.85), rgba(48, 62, 106, 0.85));
+  color: var(--accent-soft);
+  padding: 8px 16px;
+  border-radius: 10px;
+  margin-right: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+
+input[type="file"]::-webkit-file-upload-button:hover {
+  filter: brightness(1.2);
+  transform: translateY(-1px);
+}
+
+.number-input {
+  width: 90px;
+}
+
+input[type="number"] {
+  background: rgba(8, 12, 26, 0.85);
+  border: 1px solid var(--muted);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-align: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="number"]:focus-visible {
+  outline: none;
+  border-color: rgba(99, 245, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(99, 245, 255, 0.18);
+}
+
+.btn {
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(120deg, rgba(24, 30, 56, 0.9), rgba(20, 26, 46, 0.9));
+  color: var(--accent-soft);
+  padding: 10px 18px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background: linear-gradient(120deg, var(--accent) 0%, var(--accent-soft) 100%);
+  color: #050712;
+  border-color: rgba(99, 245, 255, 0.8);
+  box-shadow: 0 18px 32px -22px rgba(99, 245, 255, 0.7);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.list {
+  position: relative;
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  padding-bottom: 24px;
+}
+
+.list::before {
+  content: '';
+  position: absolute;
+  inset: -140px -220px auto auto;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(164, 141, 255, 0.2), rgba(8, 12, 26, 0));
+  pointer-events: none;
+  filter: blur(12px);
+  opacity: 0.4;
+  z-index: 0;
+}
+
+.list .section-heading {
+  padding: 26px 28px 10px;
+  margin: 0;
+}
+
+#rows {
+  position: relative;
+  z-index: 1;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 0.65fr 2fr 0.9fr 4fr 0.9fr 1.6fr 1.6fr 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 36px;
+  padding: 14px 28px;
+  font-size: 13px;
+  position: relative;
+  z-index: 1;
+}
+
+.row.header {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+  padding: 24px 28px 12px;
+  border-bottom: 1px solid rgba(82, 100, 168, 0.45);
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  background: linear-gradient(180deg, rgba(20, 28, 50, 0.9), rgba(12, 18, 36, 0.6));
+}
+
+.row.item {
+  border-bottom: 1px solid rgba(40, 52, 86, 0.4);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.row.item:hover {
+  background: rgba(18, 26, 48, 0.92);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -26px rgba(99, 245, 255, 0.6);
+}
+
+.row.altA {
+  background: var(--row-alt-a);
+}
+
+.row.altB {
+  background: var(--row-alt-b);
+}
+
+.row.item:last-of-type {
+  border-bottom: none;
+}
+
+.center {
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.right {
+  text-align: right;
+}
+
+.center-info {
+  font-size: 10px;
+  color: var(--accent-soft);
+  display: inline-flex;
+  letter-spacing: 0.12em;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+
+.chipStat {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 12px;
+  border: 1px solid rgba(82, 100, 168, 0.45);
+  background: linear-gradient(120deg, rgba(34, 44, 78, 0.85), rgba(20, 28, 52, 0.85));
+  width: 54px;
+  height: 24px;
+  box-sizing: border-box;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.stat-ico {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.35));
+}
+
+.mono {
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  width: 24px;
+  display: inline-block;
+  color: var(--accent-soft);
+}
+
+.stat-red {
+  color: var(--stat-red);
+  border-color: rgba(255, 91, 110, 0.65);
+  background: linear-gradient(120deg, rgba(68, 26, 38, 0.85), rgba(40, 20, 30, 0.85));
+  box-shadow: 0 0 8px rgba(255, 91, 110, 0.3);
+}
+
+.stat-yellow {
+  color: var(--stat-yellow);
+  border-color: rgba(255, 231, 131, 0.6);
+  background: linear-gradient(120deg, rgba(68, 58, 32, 0.85), rgba(42, 36, 22, 0.85));
+  box-shadow: 0 0 8px rgba(255, 231, 131, 0.25);
+}
+
+.stat-green {
+  color: var(--stat-green);
+  border-color: rgba(109, 255, 181, 0.6);
+  background: linear-gradient(120deg, rgba(32, 58, 44, 0.85), rgba(22, 38, 28, 0.85));
+  box-shadow: 0 0 8px rgba(109, 255, 181, 0.25);
+}
+
+.stat-cyan {
+  color: var(--stat-blue);
+  border-color: rgba(97, 228, 255, 0.6);
+  background: linear-gradient(120deg, rgba(30, 52, 72, 0.85), rgba(20, 34, 48, 0.85));
+  box-shadow: 0 0 8px rgba(97, 228, 255, 0.3);
+}
+
+.badge-warn {
+  color: #ffb38a;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  text-decoration: none;
+  background: rgba(255, 179, 138, 0.12);
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 11px;
+  border: 1px solid rgba(255, 179, 138, 0.65);
+  box-shadow: 0 0 12px -6px rgba(255, 179, 138, 0.65);
+}
+
+.badge-ok {
+  color: var(--stat-green);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  background: rgba(109, 255, 181, 0.12);
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 11px;
+  border: 1px solid rgba(109, 255, 181, 0.6);
+  box-shadow: 0 0 12px -6px rgba(109, 255, 181, 0.6);
+}
+
+.itemmeta {
+  color: var(--sub);
+  font-size: 11px;
+}
+
+.tiny {
+  font-size: 10px;
+  color: var(--accent-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.tier {
+  font-family: 'Rajdhani', monospace;
+  text-align: center;
+  color: var(--gold);
+  font-size: 18px;
+  letter-spacing: 0.1em;
+  text-shadow: 0 2px 10px rgba(42, 32, 4, 0.8);
+}
+
+.list .btn {
+  font-size: 11px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  letter-spacing: 0.12em;
+}
+
+.empty {
+  padding: 24px;
+  color: var(--sub);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.panel-empty {
+  margin: 16px 28px 0;
+  border-radius: 16px;
+  border: 1px dashed rgba(99, 245, 255, 0.3);
+  background: rgba(8, 12, 26, 0.65);
+  text-align: center;
+}
+
+.panel-empty p {
+  margin: 0;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 8px;
+  background: rgba(18, 26, 48, 0.8);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(44, 56, 92, 0.85);
+  border-radius: 8px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(76, 92, 142, 0.9);
+}
+
+@media (max-width: 1024px) {
+  .row {
+    grid-template-columns: 0.7fr 2.2fr 0.9fr 4fr 0.9fr 1.4fr 1.4fr 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .hero-grid {
+    flex-direction: column;
+  }
+
+  .hero-actions {
+    width: 100%;
+    flex: 1 1 auto;
+  }
+
+  .row {
+    grid-template-columns: 0.7fr 2.4fr 0.9fr 4fr 0.9fr 1.4fr 1.4fr 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .line {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .label {
+    min-width: 0;
+  }
+
+  .row {
+    grid-template-columns: 0.7fr 2.6fr 0.9fr 4fr 0.9fr 1.4fr 1.4fr 1fr;
+    padding: 12px 20px;
+  }
+
+  .row.header {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 620px) {
+  .row {
+    grid-template-columns: 0.7fr 2.4fr 1fr 3.6fr 1fr 1.4fr 1.4fr 1fr;
+    font-size: 12px;
+    gap: 10px;
+  }
+
+  .list .btn {
+    font-size: 10px;
+  }
+}
+
+@media (max-width: 540px) {
+  .row {
+    grid-template-columns: 0.7fr 2.6fr 1.1fr 3.6fr 1.1fr 1.4fr 1.4fr 1fr;
+  }
+
+  .hero-panel,
+  .filters-panel,
+  .list {
+    border-radius: 20px;
+  }
+}

--- a/beta.html
+++ b/beta.html
@@ -1,0 +1,516 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>D2 Armor Analyzer - By ErebusAres</title>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <link rel="stylesheet" href="beta.css" />
+</head>
+<body>
+  <div class="wrap">
+    <header class="panel hero-panel">
+      <div class="hero-grid">
+        <div class="hero-copy">
+          <h1>
+            <span class="title-prefix">Destiny 2</span>
+            <span class="title-main">Edge of Fate Armor Analyzer</span>
+          </h1>
+          <p class="tagline">Deep dive your armor rolls for the Edge of Fate meta.</p>
+          <div class="hero-hints">
+            <div class="muted">♦ Upload your DIM CSV; dupes use top‑3 stat identities within ± tolerance. Exotics compare only against same‑name items.</div>
+            <div class="muted">♦ Click "Restore last" to reload the last uploaded CSV from this browser.</div>
+            <div class="muted">♦ Click "Copy ID" or a Group Badge to copy to clipboard.</div>
+          </div>
+        </div>
+        <div class="toolbar hero-actions">
+          <span class="hero-actions-title">Data Intake</span>
+          <p class="hero-actions-sub muted">Import your latest DIM Organizer export.</p>
+          <input id="file" type="file" accept=".csv" />
+          <button class="btn" id="restoreBtn" aria-label="Restore last uploaded CSV">Restore last</button>
+          <button class="btn" id="clearBtn" aria-label="Clear all data">Clear</button>
+        </div>
+      </div>
+    </header>
+
+    <section class="panel filters-panel">
+      <div class="section-heading">
+        <h2>Loadout Filters</h2>
+        <p class="section-sub">Dial in the armor you're hunting.</p>
+      </div>
+      <div class="filters">
+        <div class="line"><span class="label">Class</span><div id="classSeg" class="seg"></div></div>
+        <div class="line"><span class="label">Rarity</span><div id="raritySeg" class="seg"></div></div>
+        <div class="line"><span class="label">Slot</span><div id="slotSeg" class="seg"></div></div>
+        <div class="line"><span class="label">Dupes</span><div id="dupesSeg" class="seg"></div></div>
+        <div class="line"><span class="label">Tolerance</span><input id="tol" class="number-input" type="number" min="0" max="20" value="5"/> <span class="muted">± top‑3 stat</span></div>
+      </div>
+    </section>
+
+    <section class="list data-panel">
+      <div class="section-heading">
+        <h2>Armor Inventory</h2>
+        <p class="section-sub">Grouped by duplicates and ranked for Edge of Fate rolls.</p>
+      </div>
+      <div class="row header">
+        <div class="center">Tag</div>
+        <div>Item</div>
+        <div class="center">Tier</div>
+        <div>Base Stats <div class="center-info">(Health, Melee, Grenade, Super, Class, Weapons)</div></div>
+        <div class="center">Total</div>
+        <div class="center">Group</div>
+        <div class="center">Rank</div>
+        <div class="right">Copy</div>
+      </div>
+      <div id="rows"></div>
+      <div id="empty" class="empty panel-empty" style="display:none"><p>
+        No items yet — upload a DIM CSV or click Restore last.<br/><br/>
+
+        To export from DIM: <br/>
+        ♦ Go to https://app.destinyitemmanager.com/ and sign in. <br/>
+        ♦ Navigate to Organizer. <br/>
+        ♦ Select any class. <br/>
+        ♦ Click the "Armor.csv" button at the top right to download your armor data. <br/>
+        ♦ Upload the downloaded CSV file here. <br/>
+      </p></div>
+    </section>
+  </div>
+
+  <script>
+  // ====== Constants ======
+  const STAT_COLS = [
+    "Health (Base)",
+    "Melee (Base)",
+    "Grenade (Base)",
+    "Super (Base)",
+    "Class (Base)",
+    "Weapons (Base)"
+  ];
+  const STAT_ICONS = {
+    "Health (Base)":"https://www.bungie.net/common/destiny2_content/icons/717b8b218cc14325a54869bef21d2964.png",
+    "Melee (Base)":"https://www.bungie.net/common/destiny2_content/icons/fa534aca76d7f2d7e7b4ba4df4271b42.png",
+    "Grenade (Base)":"https://www.bungie.net/common/destiny2_content/icons/065cdaabef560e5808e821cefaeaa22c.png",
+    "Super (Base)":"https://www.bungie.net/common/destiny2_content/icons/585ae4ede9c3da96b34086fccccdc8cd.png",
+    "Class (Base)":"https://www.bungie.net/common/destiny2_content/icons/7eb845acb5b3a4a9b7e0b2f05f5c43f1.png",
+    "Weapons (Base)":"https://www.bungie.net/common/destiny2_content/icons/bc69675acdae9e6b9a68a02fb4d62e07.png"
+  };
+  const RARITY_ICONS = {
+    "Legendary": "https://www.bungie.net/common/destiny2_content/icons/f846f489c2a97afb289b357e431ecf8d.png",
+    "Exotic": "https://www.bungie.net/common/destiny2_content/icons/3e6a698e1a8a5fb446fdcbf1e63c5269.png"
+  };
+  const CLASS_OPTIONS = ["Warlock", "Hunter", "Titan"];
+  const SLOT_OPTIONS = ["All", "Helmet", "Gauntlets", "Chest Armor", "Leg Armor", "Class Item"];
+  const RARITY_OPTIONS = ["All", "Legendary", "Exotic"];  const DUPES_OPTIONS = ["All", "Only Dupes", "Only Same-Name"];
+  const classItemByClass = { Warlock: "Warlock Bond", Hunter: "Hunter Cloak", Titan: "Titan Mark" };
+  const TAG_EMOJIS = {
+    favorite: "❤️",
+    keep: "🏷️",
+    junk: "🚫",
+    infuse: "⚡",
+    archive: "📦"
+  };
+  const TAG_LABELS = {
+    favorite: "Favorite",
+    keep: "Keep",
+    junk: "Junk",
+    infuse: "Infuse",
+    archive: "Archive"
+  };
+  const CLASS_ICONS = {
+    "Warlock": "https://www.bungie.net/common/destiny2_content/icons/e4006d9a8fe167bd7e83193d7601c89a.png",
+    "Hunter":  "https://www.bungie.net/common/destiny2_content/icons/05e32a388d9a65a0ef59b2193eee2db4.png",
+    "Titan":   "https://www.bungie.net/common/destiny2_content/icons/46a19ddd00d0f6ca822230943103b54a.png"
+  };
+  const SLOT_ICONS = {
+    "Helmet": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/helmet.svg",
+    "Gauntlets": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/gloves.svg",
+    "Chest Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/chest.svg",
+    "Leg Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/boots.svg",
+    "Class Item": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/class.svg"
+  };
+  const ARMOR_ARCHETYPES = {
+    "Grenadier": "https://www.bungie.net/common/destiny2_content/icons/cbf4f03459ab2818a3d37b7362b2aa93.png", // Grenade, Super
+    "Paragon": "https://www.bungie.net/common/destiny2_content/icons/b5feb81f684d767d6212ca138f30b34c.png", // Super, Melee
+    "Specialist": "https://www.bungie.net/common/destiny2_content/icons/69731c603d7bcdd0a21b26c711d55f03.png", // Class, Weapons
+    "Brawler": "https://www.bungie.net/common/destiny2_content/icons/7bc3bc2bccdafc19dde31f867a06ee9f.png", // Melee, Health
+    "Bulwark": "https://www.bungie.net/common/destiny2_content/icons/cda905547dd9eac7a39e6e898f619bc5.png", // Health, Class
+    "Gunner": "https://www.bungie.net/common/destiny2_content/icons/15e3b3c25a6d4606dcb887cb67c915a1.png" // Weapons, Grenade
+  }
+  // ====== Helpers ======
+  const normId = (s) => (s ? String(s).trim().replace(/^"|"$/g, "") : "");
+  const normName = (s) => String(s || "").trim().toLowerCase();
+  const num = (v) => (v == null || v === "" ? 0 : Number(v));
+  function slotNumber(type){
+    if(type === "Helmet") return 1;
+    if(type === "Gauntlets") return 2;
+    if(type === "Chest Armor") return 3;
+    if(type === "Leg Armor") return 4;
+    if(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(type)) return 5;
+    return 9;
+  }
+  function starsLegendary(t){ const n=num(t); if(n>=75) return "★★★★★"; if(n===74) return "★★★★☆"; if(n===73) return "★★★☆☆"; if(n===72) return "★★☆☆☆"; if(n===71) return "★☆☆☆☆"; return "💩"; }
+  function starsExotic(t){ const n=num(t); if(n>=63) return "★★★★★"; if(n===62) return "★★★★☆"; if(n===61) return "★★★☆☆"; if(n===60) return "★★☆☆☆"; if(n===59) return "★☆☆☆☆"; return "💩"; }
+  function statColorCls(v){ if(v>=30) return "stat-cyan"; if(v>=24) return "stat-green"; if(v>=15) return "stat-yellow"; return "stat-red"; }
+  function top3Entries(item){
+    const arr = STAT_COLS.map(k => ({ name:k, value:num(item[k]) }));
+    arr.sort((a,b)=> (b.value - a.value) || a.name.localeCompare(b.name));
+    return arr.slice(0,3);
+  }
+  function similarTop3(a,b,tol){
+    const ta = top3Entries(a), tb = top3Entries(b);
+    for(let i=0;i<3;i++){
+      if(ta[i].name !== tb[i].name) return false;
+      if(Math.abs(ta[i].value - tb[i].value) > tol) return false;
+    }
+    return true;
+  }
+  function rankScore(rank){ if(!rank) return -1; const stars=(rank.match(/★/g)||[]).length; if(stars>0) return stars; return 0; }
+  async function copyTextSafe(text){
+    try{
+      if(navigator.clipboard && window.isSecureContext){ await navigator.clipboard.writeText(text); return true; }
+      throw new Error('clipboard api not available');
+    }catch(e){
+      try{ const ta=document.createElement('textarea'); ta.value=text; ta.setAttribute('readonly',''); ta.style.position='fixed'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); const ok=document.execCommand('copy'); document.body.removeChild(ta); return ok; }catch(e2){ alert('Copy failed: '+e2); return false; }
+    }
+  }
+
+  // ====== State & Storage ======
+  let STATE = { 
+    rows:[], 
+    classFilter:'Warlock', 
+    slotFilter:'All', 
+    rarityFilter:'All', 
+    tol:5, 
+    dupesFilter:'All' // NEW
+  };
+  const LS_KEY = 'd2_armor_rows_v1';
+  function saveRows(){ try{ localStorage.setItem(LS_KEY, JSON.stringify(STATE.rows)); }catch(_){} }
+  function loadRows(){ try{ const s=localStorage.getItem(LS_KEY); if(!s) return null; return JSON.parse(s); }catch(_){ return null; } }
+
+  // ====== Filters UI ======
+  function makeSeg(containerId, options, key){
+  const el = document.getElementById(containerId); if(!el) return; el.innerHTML='';
+  options.forEach(opt => {
+    const btn = document.createElement('button');
+    btn.className = 'chip' + (STATE[key]===opt ? ' active' : '');
+    let label = opt;
+    // Add icons for class, rarity, and slot filters
+    if (containerId === 'classSeg' && CLASS_ICONS[opt]) {
+      label = `<span class="chip-icon-mask" style="mask-image:url('${CLASS_ICONS[opt]}');-webkit-mask-image:url('${CLASS_ICONS[opt]}');"></span>${opt}`;
+    }
+    if (containerId === 'raritySeg' && RARITY_ICONS[opt]) {
+      label = `<img src="${RARITY_ICONS[opt]}" alt="${opt}" title="${opt}" class="chip-icon rarity" style="height:1em;vertical-align:middle;margin-right:4px;">${opt}`;
+    }
+    if (containerId === 'slotSeg' && SLOT_ICONS[opt]) {
+      label = `<span class="chip-icon-mask" style="mask-image:url('${SLOT_ICONS[opt]}');-webkit-mask-image:url('${SLOT_ICONS[opt]}');"></span>${opt}`;
+    }
+    btn.innerHTML = (STATE[key]===opt? '● ' : '○ ') + label;
+    btn.addEventListener('click', ()=>{ STATE[key]=opt; render(); makeSeg(containerId, options, key); });
+    el.appendChild(btn);
+  });
+}
+  function initFilters(){
+    makeSeg('classSeg', CLASS_OPTIONS, 'classFilter');
+    makeSeg('raritySeg', RARITY_OPTIONS, 'rarityFilter');
+    makeSeg('slotSeg',   SLOT_OPTIONS,   'slotFilter');
+    makeSeg('dupesSeg',  DUPES_OPTIONS,  'dupesFilter'); // NEW
+  }
+
+  // ====== Data selection ======
+  function getFiltered(){
+  const expected = classItemByClass[STATE.classFilter];
+  // Always group on the full set for dupe logic
+  let baseFiltered = STATE.rows.filter(r =>
+    (STATE.classFilter ? r.Equippable === STATE.classFilter : true) &&
+    (STATE.slotFilter==='All' ? true : STATE.slotFilter==='Class Item' ? r.Type===expected : r.Type===STATE.slotFilter) &&
+    (STATE.rarityFilter==='All' ? true : r.Rarity === STATE.rarityFilter)
+  );
+  // Get all grouped rows for this filtered set
+  const grouped = clusterRows(baseFiltered);
+
+  if (STATE.dupesFilter === "Only Dupes") {
+    // Show only items in any dupe group (Dupe_Group !== "X")
+    return grouped.filter(r => r.Dupe_Group && r.Dupe_Group !== "X");
+  } else if (STATE.dupesFilter === "Only Same-Name") {
+    // Show only dupe groups where all items share the same name
+    // 1. Find all dupe groups
+    const dupeGroups = {};
+    for (const r of grouped) {
+      if (r.Dupe_Group && r.Dupe_Group !== "X") {
+        const key = `${r.GroupKey}::${r.Dupe_Group}`;
+        if (!dupeGroups[key]) dupeGroups[key] = [];
+        dupeGroups[key].push(r);
+      }
+    }
+    // 2. Keep only groups where all items have the same normalized name
+    const validIds = new Set();
+    for (const group of Object.values(dupeGroups)) {
+      const names = new Set(group.map(r => normName(r.Name)));
+      if (names.size === 1) {
+        for (const r of group) validIds.add(r.Id);
+      }
+    }
+    return grouped.filter(r => validIds.has(r.Id));
+  }
+  // Default: show all
+  return grouped;
+}
+
+  // ====== Grouping & Sorting ======
+  function clusterRows(filtered){
+    const byKey = new Map();
+    for(const r of filtered){
+      const k = r.Rarity==='Exotic' ? `${r.Type}|${normName(r.Name)}` : r.Type; // exotics cluster by name
+      if(!byKey.has(k)) byKey.set(k,[]);
+      byKey.get(k).push({...r});
+    }
+    const out=[]; const A='ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    for(const [key,items] of byKey){
+      const assigned = Array(items.length).fill(false);
+      const rawGroups = [];
+      for(let i=0;i<items.length;i++){
+        if(assigned[i]) continue;
+        const grp=[i]; assigned[i]=true;
+        for(let j=i+1;j<items.length;j++){
+          if(assigned[j]) continue;
+          if(STATE.sameNameOnly && normName(items[i].Name)!==normName(items[j].Name)) continue;
+          if(similarTop3(items[i],items[j],STATE.tol)){ grp.push(j); assigned[j]=true; }
+        }
+        rawGroups.push(grp);
+      }
+      // Order groups by best total first, then id to stabilize
+      rawGroups.sort((g1,g2)=>{
+        const best1 = Math.max(...g1.map(ix=>num(items[ix]["Total (Base)"])));
+        const best2 = Math.max(...g2.map(ix=>num(items[ix]["Total (Base)"])));
+        if(best1!==best2) return best2-best1;
+        return String(items[g1[0]].Id).localeCompare(String(items[g2[0]].Id));
+      });
+      const isExoticKey = key.includes('|');
+      let letterIdx = 0;
+      for(const grp of rawGroups){
+        const first = items[grp[0]];
+        let label = 'X';
+        if(grp.length > 1) {
+          const letter = A[Math.min(letterIdx, A.length-1)];
+          if(isExoticKey) {
+            label = `⚠️🟡${slotNumber(first.Type)}${letter}`;
+          } else {
+            label = `⚠️${slotNumber(first.Type)}${letter}`;
+          }
+          letterIdx++;
+        }
+        for(const gi of grp){
+          const it = items[gi];
+          const rank = it.Rarity==='Exotic' ? starsExotic(it["Total (Base)"]) : starsLegendary(it["Total (Base)"]); 
+          out.push({ 
+            ...it, 
+            GroupKey:key, 
+            Dupe_Group:label, 
+            Rank:rank, 
+            RankScore:rankScore(rank), 
+            Is_Dupe: label!=='X',
+            Is_Dupe_Exotic: (it.Rarity==='Exotic' && label!=='X') // <-- Add this flag
+          });
+        }
+      }
+    }
+    // Final sort: 
+out.sort((a, b) => {
+  // 1. Slot order
+  const sa = slotNumber(a.Type), sb = slotNumber(b.Type);
+  if (sa !== sb) return sa - sb;
+
+  // 2. Legendary before Exotic
+  const ra = a.Rarity === "Legendary" ? 0 : 1;
+  const rb = b.Rarity === "Legendary" ? 0 : 1;
+  if (ra !== rb) return ra - rb;
+
+  // 3. Dupe group first within each rarity
+  const da = a.Dupe_Group !== "X";
+  const db = b.Dupe_Group !== "X";
+  if (da !== db) return db - da; // true first
+
+  // 4. For dupe groups: group label, then rank desc, then total desc, then id
+  if (da && db) {
+    // Group by group key (for exotics, this is name+type)
+    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
+    if (a.Dupe_Group !== b.Dupe_Group) return String(a.Dupe_Group).localeCompare(String(b.Dupe_Group));
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // 5. For exotics: after dupe groups, show non-grouped exotics of same name below groups
+  if (a.Rarity === "Exotic" && b.Rarity === "Exotic") {
+    // GroupKey for exotics is type|name
+    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
+    // Non-grouped exotics of same name (Dupe_Group === "X") come after grouped
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // 6. For legendaries: non-dupes by name, then rank desc, then total desc, then id
+  if (a.Rarity === "Legendary" && b.Rarity === "Legendary") {
+    const na = String(a.Name).toLowerCase(), nb = String(b.Name).toLowerCase();
+    if (na !== nb) return na.localeCompare(nb);
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // Fallback: by id
+  return String(a.Id).localeCompare(String(b.Id));
+});
+    return out;
+  }
+
+  // ====== Render ======
+  function render(){
+  updateShadowColor(); 
+    const tolEl=document.getElementById('tol'); if(tolEl) tolEl.value = STATE.tol;
+    initFilters();
+
+    const grouped = getFiltered();
+
+    // Build group->ids for copy-all
+    const groupToIds = new Map();
+    for(const it of grouped){ if(it.Dupe_Group==='X') continue; const key=`${it.GroupKey||''}::${it.Dupe_Group}`; if(!groupToIds.has(key)) groupToIds.set(key,[]); groupToIds.get(key).push(normId(it.Id)); }
+
+    const host=document.getElementById('rows');
+    const empty=document.getElementById('empty');
+    host.innerHTML='';
+    if(grouped.length===0){ if(empty) empty.style.display='block'; return; } else { if(empty) empty.style.display='none'; }
+
+    let lastGroup = null;
+    let altToggle = false;
+    for(const it of grouped){
+      // Alternate shade when group changes (by Dupe_Group label)
+      if (it.Dupe_Group !== lastGroup) {
+        altToggle = !altToggle;
+        lastGroup = it.Dupe_Group;
+      }
+      const row=document.createElement('div');
+      row.className = 'row item ' + (altToggle ? 'altA' : 'altB');
+      // Tag emoji (DIM tag)
+      const cTag = document.createElement('div');
+      cTag.className = 'center';
+      const tag = (it.Tag || '').toLowerCase();
+      cTag.textContent = TAG_EMOJIS[tag] || '';
+      cTag.title = TAG_LABELS[tag] || '';
+      // Item
+      const cItem=document.createElement('div');
+      cItem.innerHTML=`<div style="font-weight:700">${it.Name}</div>
+        <div class="itemmeta">
+          ${(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(it.Type)?"Class Item":it.Type)}
+          • ${it.Equippable}
+          • <img src="${RARITY_ICONS[it.Rarity] || ''}" alt="${it.Rarity}" title="${it.Rarity}" style="height:1em;vertical-align:middle;">
+        </div>
+        <div class="tiny mono">${normId(it.Id)}</div>`;
+      // Tier
+      const cTier=document.createElement('div'); 
+      cTier.className='tier'; 
+      const tVal = Number.isFinite(it.Tier) ? Number(it.Tier) : 0; 
+      cTier.textContent = '♦'.repeat(Math.max(1, Math.min(5, tVal)));
+      // Stats chips
+      const cStats=document.createElement('div'); cStats.className='chips';
+      for(const k of STAT_COLS){
+        const pill=document.createElement('span'); pill.className=`chipStat ${statColorCls(it[k])}`; pill.title=k.replace(' (Base)','');
+        const img=document.createElement('img'); img.className='stat-ico'; img.alt=k; img.src=STAT_ICONS[k]||''; if(img.src) pill.appendChild(img);
+        const strong=document.createElement('strong'); strong.className='mono'; strong.textContent=String(it[k]||0); pill.appendChild(strong);
+        cStats.appendChild(pill);
+      }
+      // Total
+      const cTotal=document.createElement('div'); cTotal.className='center'; cTotal.style.fontWeight='700'; cTotal.textContent=String(it["Total (Base)"]||0);
+      // Group (click to copy all group ids)
+      const cGroup=document.createElement('div'); cGroup.className='center';
+      if(it.Dupe_Group!=='X'){
+        const label = it.Dupe_Group;
+        const key=`${it.GroupKey||''}::${it.Dupe_Group}`;
+        const list=(groupToIds.get(key)||[]).map(id=>`id:${id}`).join(' or ');
+        const span=document.createElement('span'); 
+        span.className='badge-warn'; 
+        span.title='Click to copy all IDs in this dupe group';
+
+        // PATCH: replace 🟡 in label with a rarity <img> for Exotic groups by assembling DOM nodes
+        // We keep label text (which might contain ⚠️🟡1A, etc.) but we render the icon instead of the 🟡
+        // Detect exotic dupe groups using the label pattern OR the item's rarity
+        const exoticGroup = /🟡/.test(label) || it.Rarity === 'Exotic';
+        if (exoticGroup && RARITY_ICONS[it.Rarity]) {
+          // Split off the visible prefix before slot/letter (remove the emoji if present)
+          const textNoYellow = label.replace('🟡','');
+          // Optional: if the label still includes the ⚠️, we keep it in text
+          // Prepend the icon after ⚠️
+          const m = textNoYellow.match(/^(⚠️)?(.*)$/);
+          const prefix = (m && m[1]) ? '⚠️' : '';
+          const rest = (m && m[2]) ? m[2] : textNoYellow;
+          if (prefix) span.append(prefix);
+
+          const img = new Image();
+          img.src = RARITY_ICONS[it.Rarity];
+          img.alt = it.Rarity;
+          img.title = it.Rarity;
+          img.style.height = '1em';
+          img.style.verticalAlign = 'middle';
+          img.style.marginRight = '4px';
+          span.appendChild(img);
+
+          span.append(rest);
+        } else {
+          // Fallback: plain text
+          span.append(label);
+        }
+        span.addEventListener('click', async ()=>{ const ok=await copyTextSafe(list); if(!ok) alert('Copy failed'); });
+        cGroup.appendChild(span);
+      } else {
+        cGroup.innerHTML = `<span class='badge-ok'>✅</span>`;
+      }
+      // Rank
+      const cRank=document.createElement('div'); cRank.className='center'; cRank.textContent=it.Rank||'';
+      // Copy single id
+      const cCopy=document.createElement('div'); cCopy.className='right';
+      const btn=document.createElement('button'); btn.className='btn'; btn.textContent='Copy id';
+      btn.addEventListener('click', async ()=>{ const ok=await copyTextSafe(`id:${normId(it.Id)}`); btn.textContent= ok? 'Copied!' : 'Copy id'; setTimeout(()=> btn.textContent='Copy id', 1200); });
+      cCopy.appendChild(btn);
+
+      row.append(cTag,cItem,cTier,cStats,cTotal,cGroup,cRank,cCopy);
+      host.appendChild(row);
+    }
+  }
+
+  // ====== Events ======
+document.getElementById('file').addEventListener('change', (e)=>{
+    const f=e.target.files?.[0]; if(!f) return;
+  Papa.parse(f,{header:true, skipEmptyLines:true, complete:(res)=>{
+    const data=res.data||[];
+    STATE.rows = data.map(r=>{ const x={...r}; for(const k of [...STAT_COLS,'Total (Base)','Tier']) { if(x[k]!==undefined) { const n = num(x[k]); x[k] = Number.isFinite(n) ? n : 0; } } x.Id=normId(x.Id); return x; });
+    saveRows();
+    render();
+    document.getElementById('file').value = '';
+  }});
+});
+document.getElementById('restoreBtn').addEventListener('click', ()=>{ const rows=loadRows(); if(rows&&Array.isArray(rows)){ STATE.rows=rows; render(); } else { alert('No saved CSV found in this browser. Upload a DIM CSV first.'); } });
+  document.getElementById('clearBtn').addEventListener('click', ()=>{ STATE.rows=[]; localStorage.removeItem(LS_KEY); document.getElementById('file').value=''; render(); });
+  document.getElementById('tol').addEventListener('input', (e)=>{ const v=Number(e.target.value); STATE.tol = isFinite(v)? v: STATE.tol; render(); });
+
+  function updateShadowColor() {
+  const root = document.documentElement;
+  if (STATE.rarityFilter === "Legendary") {
+    root.style.setProperty('--shadow', 'var(--shadow-purple)');
+  } else if (STATE.rarityFilter === "Exotic") {
+    root.style.setProperty('--shadow', 'var(--shadow-gold)');
+  } else {
+    root.style.setProperty('--shadow', '0 2px 24px 0 rgba(80,120,255,0.10)');
+  }
+}
+
+  // Initial
+  const cached = loadRows(); if(cached){ STATE.rows=cached; }
+  render();
+  updateShadowColor();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyle the beta analyzer layout with an Edge of Fate-inspired hero header, section headings, and intake panel
- rebuild the beta stylesheet to deliver a modern dark-mode palette, gradients, and updated controls for filters, tables, and stat chips

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8543b21ec832da47d6b1d66995300