### PR TITLE
Rebuild beta layout with refined Edge of Fate styling

### DIFF
--- a/beta.css
+++ b/beta.css
@@ -1,0 +1,610 @@
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&display=swap');
+
+:root {
+  --bg: #040714;
+  --bg-alt: #06091c;
+  --panel: linear-gradient(140deg, rgba(18, 26, 52, 0.92) 0%, rgba(7, 12, 28, 0.94) 100%);
+  --panel-solid: rgba(11, 18, 36, 0.92);
+  --muted: rgba(135, 146, 190, 0.8);
+  --muted2: rgba(37, 46, 78, 0.7);
+  --text: #eef3ff;
+  --sub: #8f9ac9;
+  --accent: #6dd6ff;
+  --accent-strong: #b19cff;
+  --emerald: #4ef5b3;
+  --gold: #f4ce6f;
+  --border: rgba(106, 128, 200, 0.45);
+  --border-strong: rgba(140, 122, 255, 0.55);
+  --chip-border: rgba(120, 140, 212, 0.42);
+  --shadow: 0 18px 48px -28px rgba(68, 112, 255, 0.5);
+  --shadow-purple: 0 18px 46px -28px rgba(160, 102, 255, 0.48);
+  --shadow-gold: 0 18px 46px -28px rgba(255, 210, 110, 0.45);
+  --stat-red: #ff6f7e;
+  --stat-yellow: #fce48c;
+  --stat-green: #63f7d0;
+  --stat-blue: #73e8ff;
+  --row-alt-a: rgba(20, 28, 54, 0.84);
+  --row-alt-b: rgba(13, 20, 38, 0.84);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+button {
+  font-family: inherit;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 14%, rgba(131, 112, 255, 0.18), transparent 58%),
+    radial-gradient(circle at 78% 10%, rgba(91, 227, 255, 0.16), transparent 60%),
+    linear-gradient(180deg, var(--bg-alt) 0%, var(--bg) 58%, #02040c 100%);
+  font-family: 'Rajdhani', 'Inter', 'Segoe UI', 'Roboto', sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.01em;
+  color-scheme: dark;
+}
+
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  inset: auto;
+  width: 60vmax;
+  height: 60vmax;
+  pointer-events: none;
+  filter: blur(18px);
+  opacity: 0.5;
+  z-index: 0;
+}
+
+body::before {
+  top: -20vmax;
+  left: -18vmax;
+  background: radial-gradient(circle at center, rgba(170, 146, 255, 0.28) 0%, transparent 68%);
+}
+
+body::after {
+  bottom: -28vmax;
+  right: -22vmax;
+  background: radial-gradient(circle at center, rgba(88, 226, 255, 0.22) 0%, transparent 70%);
+}
+
+.wrap {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 36px 24px 64px;
+  position: relative;
+  z-index: 1;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(30px, 4vw, 44px);
+  letter-spacing: 0.015em;
+  font-weight: 700;
+}
+
+.title-prefix {
+  display: block;
+  text-transform: uppercase;
+  font-size: 13px;
+  letter-spacing: 0.38em;
+  color: var(--sub);
+  margin-bottom: 8px;
+}
+
+.title-main {
+  display: inline-block;
+  background: linear-gradient(90deg, var(--accent-strong) 0%, var(--accent) 50%, #ffffff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 18px 38px rgba(6, 10, 26, 0.9);
+}
+
+.hero-subtitle {
+  margin: 10px 0 14px;
+  color: var(--accent);
+  font-size: 14px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero-hints {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.hero-hints li {
+  position: relative;
+  padding-left: 20px;
+}
+
+.hero-hints li::before {
+  content: '♦';
+  position: absolute;
+  left: 0;
+  color: var(--accent-strong);
+  opacity: 0.8;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel {
+  position: relative;
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  backdrop-filter: blur(8px);
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.06), transparent 70%);
+  opacity: 0.35;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.panel-spacing {
+  margin-bottom: 20px;
+}
+
+.header-grid {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+}
+
+.header-info {
+  flex: 1 1 360px;
+  min-width: 280px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+input[type="file"] {
+  color: var(--text);
+  background: var(--panel-solid);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 6px;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.btn {
+  border: 1px solid var(--accent);
+  background: linear-gradient(135deg, rgba(14, 26, 44, 0.9), rgba(20, 34, 56, 0.9));
+  color: var(--accent);
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  font-family: inherit;
+  transition: background 0.2s, color 0.2s, border 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 12px rgba(80, 160, 255, 0.18);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background: var(--accent);
+  color: #040714;
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 3px rgba(109, 214, 255, 0.25);
+}
+
+.btn:focus-visible {
+  outline: none;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.label {
+  width: 80px;
+  font-size: 12px;
+  color: var(--gold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.seg {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.seg .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--chip-border);
+  background: var(--panel-solid);
+  color: var(--text);
+  padding: 5px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, border 0.2s, background 0.2s, color 0.2s;
+}
+
+.seg .chip:hover {
+  border-color: var(--accent);
+}
+
+.seg .chip.active {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #041426;
+  border-color: transparent;
+  box-shadow: 0 6px 18px rgba(109, 214, 255, 0.35);
+}
+
+.seg .chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(109, 214, 255, 0.28);
+}
+
+.chip-indicator {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.chip-icon {
+  height: 1em;
+  width: 1em;
+  object-fit: contain;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.35));
+}
+
+.chip-icon.rarity {
+  filter: none;
+}
+
+.chip-label {
+  white-space: nowrap;
+}
+
+.number-input {
+  background: var(--panel-solid);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-family: inherit;
+  width: 80px;
+}
+
+.number-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(109, 214, 255, 0.3);
+}
+
+.list {
+  padding: 0 0 12px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 0.6fr 2fr 1fr 4fr 1fr 2fr 2fr 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 34px;
+  position: relative;
+  z-index: 1;
+}
+
+.row.header {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--gold);
+  padding: 18px 24px 12px;
+  border-bottom: 1px solid var(--muted2);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.row.item {
+  padding: 12px 24px;
+  border-bottom: 1px solid rgba(30, 40, 70, 0.6);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.row.item:hover {
+  background: rgba(109, 214, 255, 0.08);
+  transform: translateY(-1px);
+}
+
+.row.altA {
+  background: var(--row-alt-a);
+}
+
+.row.altB {
+  background: var(--row-alt-b);
+}
+
+.center,
+.right {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.right {
+  justify-content: flex-end;
+}
+
+.center-info {
+  font-size: 10px;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  margin-top: 4px;
+}
+
+.item-name {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.itemmeta {
+  color: var(--muted);
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.inline-icon {
+  height: 1em;
+  width: 1em;
+  vertical-align: middle;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.35));
+}
+
+.rarity-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tiny {
+  font-size: 10px;
+  color: var(--accent);
+  margin-top: 4px;
+}
+
+.mono {
+  font-variant-numeric: tabular-nums;
+  font-family: 'Rajdhani', 'Inter', monospace;
+  font-weight: 700;
+}
+
+.tier {
+  font-family: 'Rajdhani', monospace;
+  text-align: center;
+  color: var(--gold);
+  font-size: 18px;
+  letter-spacing: 0.08em;
+  text-shadow: 0 2px 8px rgba(10, 12, 24, 0.8);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+
+.chipStat {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 12px;
+  border: 1px solid var(--muted2);
+  background: linear-gradient(135deg, rgba(30, 38, 66, 0.95), rgba(16, 24, 46, 0.95));
+  width: 52px;
+  height: 24px;
+  border-radius: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.25);
+}
+
+.stat-ico {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.35));
+}
+
+.stat-red {
+  color: var(--stat-red);
+  border-color: rgba(255, 111, 126, 0.65);
+  background: linear-gradient(135deg, rgba(64, 24, 32, 0.92), rgba(98, 26, 40, 0.92));
+  box-shadow: 0 0 6px rgba(255, 111, 126, 0.4);
+}
+
+.stat-yellow {
+  color: var(--stat-yellow);
+  border-color: rgba(252, 228, 140, 0.65);
+  background: linear-gradient(135deg, rgba(64, 52, 20, 0.9), rgba(94, 78, 26, 0.9));
+  box-shadow: 0 0 6px rgba(252, 228, 140, 0.35);
+}
+
+.stat-green {
+  color: var(--stat-green);
+  border-color: rgba(99, 247, 208, 0.65);
+  background: linear-gradient(135deg, rgba(26, 64, 54, 0.9), rgba(32, 84, 64, 0.9));
+  box-shadow: 0 0 6px rgba(99, 247, 208, 0.35);
+}
+
+.stat-cyan {
+  color: var(--stat-blue);
+  border-color: rgba(115, 232, 255, 0.65);
+  background: linear-gradient(135deg, rgba(24, 58, 80, 0.9), rgba(22, 44, 70, 0.9));
+  box-shadow: 0 0 6px rgba(115, 232, 255, 0.35);
+}
+
+.total-strong {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.badge-warn {
+  color: var(--gold);
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: underline dotted var(--gold) 1px;
+  text-underline-offset: 4px;
+  background: rgba(244, 206, 111, 0.08);
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  border: 1px solid rgba(244, 206, 111, 0.45);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.badge-ok {
+  color: var(--emerald);
+  font-weight: 700;
+  background: rgba(78, 245, 179, 0.12);
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  border: 1px solid rgba(78, 245, 179, 0.45);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.panel-empty {
+  padding: 20px 24px 28px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: left;
+}
+
+.panel-empty a {
+  color: var(--accent);
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+::-webkit-scrollbar {
+  height: 8px;
+  width: 10px;
+  background: rgba(18, 26, 44, 0.8);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(36, 46, 72, 0.9);
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(52, 66, 100, 0.95);
+}
+
+@media (max-width: 960px) {
+  .row {
+    grid-template-columns: 0.7fr 2.2fr 1fr 3.6fr 1fr 1.8fr 1.5fr 1fr;
+    gap: 10px;
+  }
+}
+
+@media (max-width: 720px) {
+  .row {
+    grid-template-columns: 1fr 1.4fr 1fr 1.4fr;
+    grid-template-areas:
+      'item item item item'
+      'tag tier stats total'
+      'group group rank copy';
+  }
+
+  .row.header {
+    display: none;
+  }
+
+  .row.item {
+    display: grid;
+    gap: 10px;
+    border-radius: 14px;
+    margin: 12px 16px;
+    padding: 16px;
+  }
+
+  .row.item > :nth-child(1) { grid-area: tag; }
+  .row.item > :nth-child(2) { grid-area: item; }
+  .row.item > :nth-child(3) { grid-area: tier; }
+  .row.item > :nth-child(4) { grid-area: stats; }
+  .row.item > :nth-child(5) { grid-area: total; }
+  .row.item > :nth-child(6) { grid-area: group; }
+  .row.item > :nth-child(7) { grid-area: rank; }
+  .row.item > :nth-child(8) { grid-area: copy; justify-content: flex-start; }
+
+  .center,
+  .right {
+    justify-content: flex-start;
+  }
+
+  .chips {
+    flex-wrap: wrap;
+  }
+}

--- a/beta.html
+++ b/beta.html
@@ -1,0 +1,567 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>D2 Armor Analyzer Beta - Edge of Fate Theme</title>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <link rel="stylesheet" href="beta.css" />
+</head>
+<body>
+  <div class="wrap">
+    <header class="panel panel-spacing">
+      <div class="header-grid">
+        <div class="header-info">
+          <h1>
+            <span class="title-prefix">Destiny 2 Beta</span>
+            <span class="title-main">Edge of Fate Armor Analyzer</span>
+          </h1>
+          <p class="hero-subtitle">Dark mode beta styling inspired by the Edge of Fate aesthetic.</p>
+          <ul class="hero-hints">
+            <li>Upload your DIM CSV; duplicates use top-3 stat identities within ± tolerance. Exotics compare only against same-name items.</li>
+            <li>Click "Restore last" to reload the last uploaded CSV from this browser.</li>
+            <li>Click "Copy ID" or a group badge to copy to clipboard.</li>
+          </ul>
+        </div>
+        <div class="toolbar">
+          <input id="file" type="file" accept=".csv" />
+          <button class="btn" id="restoreBtn" aria-label="Restore last uploaded CSV">Restore last</button>
+          <button class="btn" id="clearBtn" aria-label="Clear all data">Clear</button>
+        </div>
+      </div>
+    </header>
+
+    <section class="panel panel-spacing">
+      <div class="filters">
+        <div class="line">
+          <span class="label">Class</span>
+          <div id="classSeg" class="seg"></div>
+        </div>
+        <div class="line">
+          <span class="label">Rarity</span>
+          <div id="raritySeg" class="seg"></div>
+        </div>
+        <div class="line">
+          <span class="label">Slot</span>
+          <div id="slotSeg" class="seg"></div>
+        </div>
+        <div class="line">
+          <span class="label">Dupes</span>
+          <div id="dupesSeg" class="seg"></div>
+        </div>
+        <div class="line">
+          <span class="label">Tolerance</span>
+          <input id="tol" class="number-input" type="number" min="0" max="20" value="5" />
+          <span class="muted">± top-3 stat</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel list">
+      <div class="row header">
+        <div class="center">Tag</div>
+        <div>Item</div>
+        <div class="center">Tier</div>
+        <div>Base Stats <div class="center-info">(Health, Melee, Grenade, Super, Class, Weapons)</div></div>
+        <div class="center">Total</div>
+        <div class="center">Group</div>
+        <div class="center">Rank</div>
+        <div class="right">Copy</div>
+      </div>
+      <div id="rows"></div>
+      <div id="empty" class="empty panel-empty is-hidden">
+        <p>
+          No items yet — upload a DIM CSV or click Restore last.<br/><br/>
+          To export from DIM: <br/>
+          ♦ Go to https://app.destinyitemmanager.com/ and sign in. <br/>
+          ♦ Navigate to Organizer. <br/>
+          ♦ Select any class. <br/>
+          ♦ Click the "Armor.csv" button at the top right to download your armor data. <br/>
+          ♦ Upload the downloaded CSV file here. <br/>
+        </p>
+      </div>
+    </section>
+  </div>
+
+  <script>
+  // ====== Constants ======
+  const STAT_COLS = [
+    "Health (Base)",
+    "Melee (Base)",
+    "Grenade (Base)",
+    "Super (Base)",
+    "Class (Base)",
+    "Weapons (Base)"
+  ];
+  const STAT_ICONS = {
+    "Health (Base)":"https://www.bungie.net/common/destiny2_content/icons/717b8b218cc14325a54869bef21d2964.png",
+    "Melee (Base)":"https://www.bungie.net/common/destiny2_content/icons/fa534aca76d7f2d7e7b4ba4df4271b42.png",
+    "Grenade (Base)":"https://www.bungie.net/common/destiny2_content/icons/065cdaabef560e5808e821cefaeaa22c.png",
+    "Super (Base)":"https://www.bungie.net/common/destiny2_content/icons/585ae4ede9c3da96b34086fccccdc8cd.png",
+    "Class (Base)":"https://www.bungie.net/common/destiny2_content/icons/7eb845acb5b3a4a9b7e0b2f05f5c43f1.png",
+    "Weapons (Base)":"https://www.bungie.net/common/destiny2_content/icons/bc69675acdae9e6b9a68a02fb4d62e07.png"
+  };
+  const RARITY_ICONS = {
+    "Legendary": "https://www.bungie.net/common/destiny2_content/icons/f846f489c2a97afb289b357e431ecf8d.png",
+    "Exotic": "https://www.bungie.net/common/destiny2_content/icons/3e6a698e1a8a5fb446fdcbf1e63c5269.png"
+  };
+  const CLASS_OPTIONS = ["Warlock", "Hunter", "Titan"];
+  const SLOT_OPTIONS = ["All", "Helmet", "Gauntlets", "Chest Armor", "Leg Armor", "Class Item"];
+  const RARITY_OPTIONS = ["All", "Legendary", "Exotic"];  const DUPES_OPTIONS = ["All", "Only Dupes", "Only Same-Name"];
+  const classItemByClass = { Warlock: "Warlock Bond", Hunter: "Hunter Cloak", Titan: "Titan Mark" };
+  const TAG_EMOJIS = {
+    favorite: "❤️",
+    keep: "🏷️",
+    junk: "🚫",
+    infuse: "⚡",
+    archive: "📦"
+  };
+  const TAG_LABELS = {
+    favorite: "Favorite",
+    keep: "Keep",
+    junk: "Junk",
+    infuse: "Infuse",
+    archive: "Archive"
+  };
+  const CLASS_ICONS = {
+    "Warlock": "https://www.bungie.net/common/destiny2_content/icons/e4006d9a8fe167bd7e83193d7601c89a.png",
+    "Hunter":  "https://www.bungie.net/common/destiny2_content/icons/05e32a388d9a65a0ef59b2193eee2db4.png",
+    "Titan":   "https://www.bungie.net/common/destiny2_content/icons/46a19ddd00d0f6ca822230943103b54a.png"
+  };
+  const SLOT_ICONS = {
+    "Helmet": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/helmet.svg",
+    "Gauntlets": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/gloves.svg",
+    "Chest Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/chest.svg",
+    "Leg Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/boots.svg",
+    "Class Item": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/class.svg"
+  };
+  const ARMOR_ARCHETYPES = {
+    "Grenadier": "https://www.bungie.net/common/destiny2_content/icons/cbf4f03459ab2818a3d37b7362b2aa93.png", // Grenade, Super
+    "Paragon": "https://www.bungie.net/common/destiny2_content/icons/b5feb81f684d767d6212ca138f30b34c.png", // Super, Melee
+    "Specialist": "https://www.bungie.net/common/destiny2_content/icons/69731c603d7bcdd0a21b26c711d55f03.png", // Class, Weapons
+    "Brawler": "https://www.bungie.net/common/destiny2_content/icons/7bc3bc2bccdafc19dde31f867a06ee9f.png", // Melee, Health
+    "Bulwark": "https://www.bungie.net/common/destiny2_content/icons/cda905547dd9eac7a39e6e898f619bc5.png", // Health, Class
+    "Gunner": "https://www.bungie.net/common/destiny2_content/icons/15e3b3c25a6d4606dcb887cb67c915a1.png" // Weapons, Grenade
+  }
+  // ====== Helpers ======
+  const normId = (s) => (s ? String(s).trim().replace(/^"|"$/g, "") : "");
+  const normName = (s) => String(s || "").trim().toLowerCase();
+  const num = (v) => (v == null || v === "" ? 0 : Number(v));
+  function slotNumber(type){
+    if(type === "Helmet") return 1;
+    if(type === "Gauntlets") return 2;
+    if(type === "Chest Armor") return 3;
+    if(type === "Leg Armor") return 4;
+    if(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(type)) return 5;
+    return 9;
+  }
+  function starsLegendary(t){ const n=num(t); if(n>=75) return "★★★★★"; if(n===74) return "★★★★☆"; if(n===73) return "★★★☆☆"; if(n===72) return "★★☆☆☆"; if(n===71) return "★☆☆☆☆"; return "💩"; }
+  function starsExotic(t){ const n=num(t); if(n>=63) return "★★★★★"; if(n===62) return "★★★★☆"; if(n===61) return "★★★☆☆"; if(n===60) return "★★☆☆☆"; if(n===59) return "★☆☆☆☆"; return "💩"; }
+  function statColorCls(v){ if(v>=30) return "stat-cyan"; if(v>=24) return "stat-green"; if(v>=15) return "stat-yellow"; return "stat-red"; }
+  function top3Entries(item){
+    const arr = STAT_COLS.map(k => ({ name:k, value:num(item[k]) }));
+    arr.sort((a,b)=> (b.value - a.value) || a.name.localeCompare(b.name));
+    return arr.slice(0,3);
+  }
+  function similarTop3(a,b,tol){
+    const ta = top3Entries(a), tb = top3Entries(b);
+    for(let i=0;i<3;i++){
+      if(ta[i].name !== tb[i].name) return false;
+      if(Math.abs(ta[i].value - tb[i].value) > tol) return false;
+    }
+    return true;
+  }
+  function rankScore(rank){ if(!rank) return -1; const stars=(rank.match(/★/g)||[]).length; if(stars>0) return stars; return 0; }
+  async function copyTextSafe(text){
+    try{
+      if(navigator.clipboard && window.isSecureContext){ await navigator.clipboard.writeText(text); return true; }
+      throw new Error('clipboard api not available');
+    }catch(e){
+      try{ const ta=document.createElement('textarea'); ta.value=text; ta.setAttribute('readonly',''); ta.style.position='fixed'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); const ok=document.execCommand('copy'); document.body.removeChild(ta); return ok; }catch(e2){ alert('Copy failed: '+e2); return false; }
+    }
+  }
+
+  // ====== State & Storage ======
+  let STATE = { 
+    rows:[], 
+    classFilter:'Warlock', 
+    slotFilter:'All', 
+    rarityFilter:'All', 
+    tol:5, 
+    dupesFilter:'All' // NEW
+  };
+  const LS_KEY = 'd2_armor_rows_v1';
+  function saveRows(){ try{ localStorage.setItem(LS_KEY, JSON.stringify(STATE.rows)); }catch(_){} }
+  function loadRows(){ try{ const s=localStorage.getItem(LS_KEY); if(!s) return null; return JSON.parse(s); }catch(_){ return null; } }
+
+  // ====== Filters UI ======
+  function makeSeg(containerId, options, key){
+    const el = document.getElementById(containerId);
+    if(!el) return;
+    el.innerHTML='';
+    options.forEach(opt => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      const isActive = STATE[key]===opt;
+      btn.className = 'chip' + (isActive ? ' active' : '');
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+
+      const indicator = document.createElement('span');
+      indicator.className = 'chip-indicator';
+      indicator.textContent = isActive ? '●' : '○';
+      btn.appendChild(indicator);
+
+      const maybeIcon = (src, extraClass = '') => {
+        if(!src) return;
+        const icon = document.createElement('img');
+        icon.src = src;
+        icon.alt = opt;
+        icon.title = opt;
+        icon.loading = 'lazy';
+        icon.className = 'chip-icon' + (extraClass ? ' ' + extraClass : '');
+        btn.appendChild(icon);
+      };
+
+      if(containerId === 'classSeg'){
+        maybeIcon(CLASS_ICONS[opt]);
+      } else if(containerId === 'raritySeg'){
+        maybeIcon(RARITY_ICONS[opt], 'rarity');
+      } else if(containerId === 'slotSeg'){
+        maybeIcon(SLOT_ICONS[opt]);
+      }
+
+      const label = document.createElement('span');
+      label.className = 'chip-label';
+      label.textContent = opt;
+      btn.appendChild(label);
+
+      btn.addEventListener('click', ()=>{ STATE[key]=opt; render(); makeSeg(containerId, options, key); });
+      el.appendChild(btn);
+    });
+  }
+  function initFilters(){
+    makeSeg('classSeg', CLASS_OPTIONS, 'classFilter');
+    makeSeg('raritySeg', RARITY_OPTIONS, 'rarityFilter');
+    makeSeg('slotSeg',   SLOT_OPTIONS,   'slotFilter');
+    makeSeg('dupesSeg',  DUPES_OPTIONS,  'dupesFilter'); // NEW
+  }
+
+  // ====== Data selection ======
+  function getFiltered(){
+  const expected = classItemByClass[STATE.classFilter];
+  // Always group on the full set for dupe logic
+  let baseFiltered = STATE.rows.filter(r =>
+    (STATE.classFilter ? r.Equippable === STATE.classFilter : true) &&
+    (STATE.slotFilter==='All' ? true : STATE.slotFilter==='Class Item' ? r.Type===expected : r.Type===STATE.slotFilter) &&
+    (STATE.rarityFilter==='All' ? true : r.Rarity === STATE.rarityFilter)
+  );
+  // Get all grouped rows for this filtered set
+  const grouped = clusterRows(baseFiltered);
+
+  if (STATE.dupesFilter === "Only Dupes") {
+    // Show only items in any dupe group (Dupe_Group !== "X")
+    return grouped.filter(r => r.Dupe_Group && r.Dupe_Group !== "X");
+  } else if (STATE.dupesFilter === "Only Same-Name") {
+    // Show only dupe groups where all items share the same name
+    // 1. Find all dupe groups
+    const dupeGroups = {};
+    for (const r of grouped) {
+      if (r.Dupe_Group && r.Dupe_Group !== "X") {
+        const key = `${r.GroupKey}::${r.Dupe_Group}`;
+        if (!dupeGroups[key]) dupeGroups[key] = [];
+        dupeGroups[key].push(r);
+      }
+    }
+    // 2. Keep only groups where all items have the same normalized name
+    const validIds = new Set();
+    for (const group of Object.values(dupeGroups)) {
+      const names = new Set(group.map(r => normName(r.Name)));
+      if (names.size === 1) {
+        for (const r of group) validIds.add(r.Id);
+      }
+    }
+    return grouped.filter(r => validIds.has(r.Id));
+  }
+  // Default: show all
+  return grouped;
+}
+
+  // ====== Grouping & Sorting ======
+  function clusterRows(filtered){
+    const byKey = new Map();
+    for(const r of filtered){
+      const k = r.Rarity==='Exotic' ? `${r.Type}|${normName(r.Name)}` : r.Type; // exotics cluster by name
+      if(!byKey.has(k)) byKey.set(k,[]);
+      byKey.get(k).push({...r});
+    }
+    const out=[]; const A='ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    for(const [key,items] of byKey){
+      const assigned = Array(items.length).fill(false);
+      const rawGroups = [];
+      for(let i=0;i<items.length;i++){
+        if(assigned[i]) continue;
+        const grp=[i]; assigned[i]=true;
+        for(let j=i+1;j<items.length;j++){
+          if(assigned[j]) continue;
+          if(STATE.sameNameOnly && normName(items[i].Name)!==normName(items[j].Name)) continue;
+          if(similarTop3(items[i],items[j],STATE.tol)){ grp.push(j); assigned[j]=true; }
+        }
+        rawGroups.push(grp);
+      }
+      // Order groups by best total first, then id to stabilize
+      rawGroups.sort((g1,g2)=>{
+        const best1 = Math.max(...g1.map(ix=>num(items[ix]["Total (Base)"])));
+        const best2 = Math.max(...g2.map(ix=>num(items[ix]["Total (Base)"])));
+        if(best1!==best2) return best2-best1;
+        return String(items[g1[0]].Id).localeCompare(String(items[g2[0]].Id));
+      });
+      const isExoticKey = key.includes('|');
+      let letterIdx = 0;
+      for(const grp of rawGroups){
+        const first = items[grp[0]];
+        let label = 'X';
+        if(grp.length > 1) {
+          const letter = A[Math.min(letterIdx, A.length-1)];
+          if(isExoticKey) {
+            label = `⚠️🟡${slotNumber(first.Type)}${letter}`;
+          } else {
+            label = `⚠️${slotNumber(first.Type)}${letter}`;
+          }
+          letterIdx++;
+        }
+        for(const gi of grp){
+          const it = items[gi];
+          const rank = it.Rarity==='Exotic' ? starsExotic(it["Total (Base)"]) : starsLegendary(it["Total (Base)"]); 
+          out.push({ 
+            ...it, 
+            GroupKey:key, 
+            Dupe_Group:label, 
+            Rank:rank, 
+            RankScore:rankScore(rank), 
+            Is_Dupe: label!=='X',
+            Is_Dupe_Exotic: (it.Rarity==='Exotic' && label!=='X') // <-- Add this flag
+          });
+        }
+      }
+    }
+    // Final sort: 
+out.sort((a, b) => {
+  // 1. Slot order
+  const sa = slotNumber(a.Type), sb = slotNumber(b.Type);
+  if (sa !== sb) return sa - sb;
+
+  // 2. Legendary before Exotic
+  const ra = a.Rarity === "Legendary" ? 0 : 1;
+  const rb = b.Rarity === "Legendary" ? 0 : 1;
+  if (ra !== rb) return ra - rb;
+
+  // 3. Dupe group first within each rarity
+  const da = a.Dupe_Group !== "X";
+  const db = b.Dupe_Group !== "X";
+  if (da !== db) return db - da; // true first
+
+  // 4. For dupe groups: group label, then rank desc, then total desc, then id
+  if (da && db) {
+    // Group by group key (for exotics, this is name+type)
+    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
+    if (a.Dupe_Group !== b.Dupe_Group) return String(a.Dupe_Group).localeCompare(String(b.Dupe_Group));
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // 5. For exotics: after dupe groups, show non-grouped exotics of same name below groups
+  if (a.Rarity === "Exotic" && b.Rarity === "Exotic") {
+    // GroupKey for exotics is type|name
+    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
+    // Non-grouped exotics of same name (Dupe_Group === "X") come after grouped
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // 6. For legendaries: non-dupes by name, then rank desc, then total desc, then id
+  if (a.Rarity === "Legendary" && b.Rarity === "Legendary") {
+    const na = String(a.Name).toLowerCase(), nb = String(b.Name).toLowerCase();
+    if (na !== nb) return na.localeCompare(nb);
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // Fallback: by id
+  return String(a.Id).localeCompare(String(b.Id));
+});
+    return out;
+  }
+
+  // ====== Render ======
+  function render(){
+  updateShadowColor(); 
+    const tolEl=document.getElementById('tol'); if(tolEl) tolEl.value = STATE.tol;
+    initFilters();
+
+    const grouped = getFiltered();
+
+    // Build group->ids for copy-all
+    const groupToIds = new Map();
+    for(const it of grouped){ if(it.Dupe_Group==='X') continue; const key=`${it.GroupKey||''}::${it.Dupe_Group}`; if(!groupToIds.has(key)) groupToIds.set(key,[]); groupToIds.get(key).push(normId(it.Id)); }
+
+    const host=document.getElementById('rows');
+    const empty=document.getElementById('empty');
+    host.innerHTML='';
+    if(grouped.length===0){ if(empty) empty.classList.remove('is-hidden'); return; } else if(empty) { empty.classList.add('is-hidden'); }
+
+    let lastGroup = null;
+    let altToggle = false;
+    for(const it of grouped){
+      // Alternate shade when group changes (by Dupe_Group label)
+      if (it.Dupe_Group !== lastGroup) {
+        altToggle = !altToggle;
+        lastGroup = it.Dupe_Group;
+      }
+      const row=document.createElement('div');
+      row.className = 'row item ' + (altToggle ? 'altA' : 'altB');
+      // Tag emoji (DIM tag)
+      const cTag = document.createElement('div');
+      cTag.className = 'center';
+      const tag = (it.Tag || '').toLowerCase();
+      cTag.textContent = TAG_EMOJIS[tag] || '';
+      cTag.title = TAG_LABELS[tag] || '';
+      // Item
+      const cItem=document.createElement('div');
+      const nameEl=document.createElement('div');
+      nameEl.className='item-name';
+      nameEl.textContent=it.Name;
+      cItem.appendChild(nameEl);
+
+      const meta=document.createElement('div');
+      meta.className='itemmeta';
+      const typeLabel = (["Warlock Bond","Hunter Cloak","Titan Mark"].includes(it.Type)?"Class Item":it.Type);
+      meta.append(typeLabel);
+      meta.append(' • ');
+      meta.append(it.Equippable);
+      if(RARITY_ICONS[it.Rarity]){
+        meta.append(' • ');
+        const rarityIcon=document.createElement('img');
+        rarityIcon.src=RARITY_ICONS[it.Rarity];
+        rarityIcon.alt=it.Rarity;
+        rarityIcon.title=it.Rarity;
+        rarityIcon.className='inline-icon';
+        meta.appendChild(rarityIcon);
+        const rarityText=document.createElement('span');
+        rarityText.className='rarity-label';
+        rarityText.textContent=it.Rarity;
+        meta.appendChild(rarityText);
+      }
+      cItem.appendChild(meta);
+
+      const idEl=document.createElement('div');
+      idEl.className='tiny mono';
+      idEl.textContent=normId(it.Id);
+      cItem.appendChild(idEl);
+      // Tier
+      const cTier=document.createElement('div'); 
+      cTier.className='tier'; 
+      const tVal = Number.isFinite(it.Tier) ? Number(it.Tier) : 0; 
+      cTier.textContent = '♦'.repeat(Math.max(1, Math.min(5, tVal)));
+      // Stats chips
+      const cStats=document.createElement('div'); cStats.className='chips';
+      for(const k of STAT_COLS){
+        const pill=document.createElement('span'); pill.className=`chipStat ${statColorCls(it[k])}`; pill.title=k.replace(' (Base)','');
+        const img=document.createElement('img'); img.className='stat-ico'; img.alt=k; img.src=STAT_ICONS[k]||''; if(img.src) pill.appendChild(img);
+        const strong=document.createElement('strong'); strong.className='mono'; strong.textContent=String(it[k]||0); pill.appendChild(strong);
+        cStats.appendChild(pill);
+      }
+      // Total
+      const cTotal=document.createElement('div'); cTotal.className='center total-strong'; cTotal.textContent=String(it["Total (Base)"]||0);
+      // Group (click to copy all group ids)
+      const cGroup=document.createElement('div'); cGroup.className='center';
+      if(it.Dupe_Group!=='X'){
+        const label = it.Dupe_Group;
+        const key=`${it.GroupKey||''}::${it.Dupe_Group}`;
+        const list=(groupToIds.get(key)||[]).map(id=>`id:${id}`).join(' or ');
+        const span=document.createElement('span'); 
+        span.className='badge-warn'; 
+        span.title='Click to copy all IDs in this dupe group';
+
+        // PATCH: replace 🟡 in label with a rarity <img> for Exotic groups by assembling DOM nodes
+        // We keep label text (which might contain ⚠️🟡1A, etc.) but we render the icon instead of the 🟡
+        // Detect exotic dupe groups using the label pattern OR the item's rarity
+        const exoticGroup = /🟡/.test(label) || it.Rarity === 'Exotic';
+        if (exoticGroup && RARITY_ICONS[it.Rarity]) {
+          // Split off the visible prefix before slot/letter (remove the emoji if present)
+          const textNoYellow = label.replace('🟡','');
+          // Optional: if the label still includes the ⚠️, we keep it in text
+          // Prepend the icon after ⚠️
+          const m = textNoYellow.match(/^(⚠️)?(.*)$/);
+          const prefix = (m && m[1]) ? '⚠️' : '';
+          const rest = (m && m[2]) ? m[2] : textNoYellow;
+          if (prefix) span.append(prefix);
+
+          const img = document.createElement('img');
+          img.src = RARITY_ICONS[it.Rarity];
+          img.alt = it.Rarity;
+          img.title = it.Rarity;
+          img.className = 'inline-icon';
+          span.appendChild(img);
+
+          span.append(rest);
+        } else {
+          // Fallback: plain text
+          span.append(label);
+        }
+        span.addEventListener('click', async ()=>{ const ok=await copyTextSafe(list); if(!ok) alert('Copy failed'); });
+        cGroup.appendChild(span);
+      } else {
+        cGroup.innerHTML = `<span class='badge-ok'>✅</span>`;
+      }
+      // Rank
+      const cRank=document.createElement('div'); cRank.className='center'; cRank.textContent=it.Rank||'';
+      // Copy single id
+      const cCopy=document.createElement('div'); cCopy.className='right';
+      const btn=document.createElement('button'); btn.type='button'; btn.className='btn'; btn.textContent='Copy id';
+      btn.addEventListener('click', async ()=>{ const ok=await copyTextSafe(`id:${normId(it.Id)}`); btn.textContent= ok? 'Copied!' : 'Copy id'; setTimeout(()=> btn.textContent='Copy id', 1200); });
+      cCopy.appendChild(btn);
+
+      row.append(cTag,cItem,cTier,cStats,cTotal,cGroup,cRank,cCopy);
+      host.appendChild(row);
+    }
+  }
+
+  // ====== Events ======
+document.getElementById('file').addEventListener('change', (e)=>{
+    const f=e.target.files?.[0]; if(!f) return;
+  Papa.parse(f,{header:true, skipEmptyLines:true, complete:(res)=>{
+    const data=res.data||[];
+    STATE.rows = data.map(r=>{ const x={...r}; for(const k of [...STAT_COLS,'Total (Base)','Tier']) { if(x[k]!==undefined) { const n = num(x[k]); x[k] = Number.isFinite(n) ? n : 0; } } x.Id=normId(x.Id); return x; });
+    saveRows();
+    render();
+    document.getElementById('file').value = '';
+  }});
+});
+document.getElementById('restoreBtn').addEventListener('click', ()=>{ const rows=loadRows(); if(rows&&Array.isArray(rows)){ STATE.rows=rows; render(); } else { alert('No saved CSV found in this browser. Upload a DIM CSV first.'); } });
+  document.getElementById('clearBtn').addEventListener('click', ()=>{ STATE.rows=[]; localStorage.removeItem(LS_KEY); document.getElementById('file').value=''; render(); });
+  document.getElementById('tol').addEventListener('input', (e)=>{ const v=Number(e.target.value); STATE.tol = isFinite(v)? v: STATE.tol; render(); });
+
+  function updateShadowColor() {
+  const root = document.documentElement;
+  if (STATE.rarityFilter === "Legendary") {
+    root.style.setProperty('--shadow', 'var(--shadow-purple)');
+  } else if (STATE.rarityFilter === "Exotic") {
+    root.style.setProperty('--shadow', 'var(--shadow-gold)');
+  } else {
+    root.style.setProperty('--shadow', '0 2px 24px 0 rgba(80,120,255,0.10)');
+  }
+}
+
+  // Initial
+  const cached = loadRows(); if(cached){ STATE.rows=cached; }
+  render();
+  updateShadowColor();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restructure the beta header, filters, and list markup to align with the base analyzer while keeping the Edge of Fate guidance copy
- replace the oversized beta stylesheet with a concise Edge of Fate palette and component styles for panels, filters, and stat rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8543b21ec832da47d6b1d66995300