### PR TITLE
Add beta theme variant with external styling

### DIFF
--- a/beta.css
+++ b/beta.css
@@ -1,0 +1,521 @@
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;700&display=swap');
+
+:root {
+  --bg: #05060f;
+  --starfield: radial-gradient(circle at 20% 20%, rgba(124, 215, 255, 0.08), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(159, 133, 255, 0.1), transparent 52%),
+    linear-gradient(140deg, rgba(10, 14, 26, 0.92), rgba(6, 8, 18, 0.95));
+  --panel: linear-gradient(135deg, rgba(28, 38, 68, 0.88), rgba(16, 24, 45, 0.96));
+  --panel2: rgba(12, 20, 40, 0.84);
+  --muted: rgba(126, 146, 196, 0.34);
+  --muted2: rgba(126, 146, 196, 0.18);
+  --text: #edf1ff;
+  --sub: #7d88a6;
+  --emerald: #3debb9;
+  --accent: #7cd7ff;
+  --accent-strong: #9f85ff;
+  --orange: #ffb17f;
+  --purple: #9f85ff;
+  --gold: #ffe8a3;
+  --border: rgba(120, 160, 255, 0.35);
+  --border-strong: rgba(120, 160, 255, 0.6);
+  --shadow-base: 0 28px 80px -40px rgba(86, 140, 255, 0.6);
+  --shadow: var(--shadow-base);
+  --shadow-purple: 0 24px 72px -38px rgba(159, 133, 255, 0.65);
+  --shadow-gold: 0 24px 72px -38px rgba(255, 218, 140, 0.7);
+  --glow: 0 0 24px rgba(124, 215, 255, 0.35);
+  --chip-bg: rgba(116, 152, 255, 0.12);
+  --chip-hover: rgba(159, 133, 255, 0.28);
+  --chip-active-text: #04070f;
+  --stat-red: #ff6b81;
+  --stat-yellow: #ffe98a;
+  --stat-green: #48f5c1;
+  --stat-blue: #82deff;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--bg);
+  background-image: var(--starfield);
+  background-attachment: fixed;
+  color: var(--text);
+  font-family: 'Rajdhani', 'Inter', 'Segoe UI', 'Roboto', Arial, sans-serif;
+  letter-spacing: 0.01em;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -30vh -30vw;
+  background: radial-gradient(circle at 60% 20%, rgba(124, 215, 255, 0.35), transparent 60%),
+    radial-gradient(circle at 10% 80%, rgba(73, 108, 220, 0.4), transparent 60%);
+  filter: blur(160px);
+  opacity: 0.65;
+  z-index: -2;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(8, 12, 26, 0.65) 0%, transparent 45%, rgba(4, 6, 12, 0.95) 100%);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.wrap {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(24px, 4vw, 36px);
+  position: relative;
+  z-index: 1;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  text-shadow: 0 0 18px rgba(124, 215, 255, 0.45);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+h1::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(124, 215, 255, 0.4), transparent);
+}
+
+.muted {
+  color: var(--sub);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 18px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+  isolation: isolate;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 60%, transparent 100%);
+  opacity: 0.9;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.btn {
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(120deg, rgba(124, 215, 255, 0.15), rgba(159, 133, 255, 0.08));
+  color: var(--accent);
+  padding: 6px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  backdrop-filter: blur(12px);
+}
+
+.btn:hover {
+  background: var(--accent);
+  color: var(--chip-active-text);
+  border-color: var(--accent);
+  box-shadow: var(--glow);
+  transform: translateY(-1px);
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.label {
+  width: 92px;
+  font-size: 12px;
+  color: var(--accent-strong);
+  letter-spacing: 0.12em;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  text-transform: uppercase;
+}
+
+.seg {
+  display: inline-flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.seg .chip {
+  border: 1px solid var(--muted);
+  background: var(--chip-bg);
+  color: var(--text);
+  padding: 5px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  backdrop-filter: blur(8px);
+}
+
+.seg .chip.active {
+  background: var(--accent);
+  color: var(--chip-active-text);
+  border-color: var(--accent);
+  box-shadow: 0 0 18px rgba(124, 215, 255, 0.4);
+}
+
+.seg .chip:hover:not(.active) {
+  border-color: var(--accent-strong);
+  background: var(--chip-hover);
+}
+
+.chip .chip-icon:not(.rarity) {
+  filter: saturate(0.4) brightness(1.2) opacity(0.85);
+  transition: filter 0.2s ease;
+}
+
+.chip.active .chip-icon:not(.rarity),
+.seg .chip:hover .chip-icon:not(.rarity) {
+  filter: none;
+}
+
+.chip-icon.rarity {
+  filter: none !important;
+}
+
+.list {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 18px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(20px);
+}
+
+.list::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(160deg, rgba(124, 215, 255, 0.08), transparent 40%),
+    repeating-linear-gradient(135deg, transparent, transparent 14px, rgba(255, 255, 255, 0.03) 14px, rgba(255, 255, 255, 0.03) 18px);
+  z-index: 0;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 0.6fr 2fr 1fr 4fr 1fr 2fr 2fr 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 32px;
+  position: relative;
+  z-index: 1;
+}
+
+.row.header {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent-strong);
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--muted);
+  letter-spacing: 0.12em;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  text-transform: uppercase;
+  background: none !important;
+}
+
+.row.item {
+  padding: 4px 0;
+  border-bottom: 1px solid var(--muted2);
+  transition: background 0.25s ease, border 0.25s ease;
+  min-height: 34px;
+}
+
+.row.item:hover {
+  background: rgba(124, 215, 255, 0.08);
+  border-color: rgba(124, 215, 255, 0.25);
+}
+
+.row.altA {
+  background: rgba(14, 20, 40, 0.72);
+}
+
+.row.altB {
+  background: rgba(9, 14, 28, 0.72);
+}
+
+.empty {
+  padding: 16px;
+  color: var(--sub);
+  font-size: 13px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+
+.chipStat {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 12px;
+  border: 1.5px solid var(--muted);
+  background: linear-gradient(120deg, rgba(32, 46, 80, 0.85), rgba(22, 34, 60, 0.9));
+  width: 52px;
+  height: 22px;
+  box-sizing: border-box;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 1px 4px rgba(12, 18, 30, 0.4), 0 0 2px rgba(0, 0, 0, 0.3);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.chipStat:hover {
+  transform: translateY(-1px);
+  border-color: rgba(124, 215, 255, 0.5);
+}
+
+.stat-ico {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.35));
+}
+
+.mono {
+  font-variant-numeric: tabular-nums;
+  font-family: 'Rajdhani', 'Inter', monospace;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  width: 22px;
+  display: inline-block;
+}
+
+.stat-red {
+  color: var(--stat-red);
+  border-color: rgba(255, 107, 129, 0.6);
+  background: linear-gradient(120deg, rgba(56, 24, 36, 0.95), rgba(87, 32, 48, 0.9));
+  box-shadow: 0 0 10px rgba(255, 107, 129, 0.3);
+}
+
+.stat-yellow {
+  color: var(--stat-yellow);
+  border-color: rgba(255, 233, 138, 0.6);
+  background: linear-gradient(120deg, rgba(61, 52, 28, 0.95), rgba(94, 80, 40, 0.9));
+  box-shadow: 0 0 10px rgba(255, 233, 138, 0.28);
+}
+
+.stat-green {
+  color: var(--stat-green);
+  border-color: rgba(72, 245, 193, 0.6);
+  background: linear-gradient(120deg, rgba(24, 56, 44, 0.95), rgba(32, 74, 56, 0.9));
+  box-shadow: 0 0 10px rgba(72, 245, 193, 0.28);
+}
+
+.stat-cyan {
+  color: var(--stat-blue);
+  border-color: rgba(130, 222, 255, 0.6);
+  background: linear-gradient(120deg, rgba(24, 52, 68, 0.95), rgba(30, 62, 84, 0.9));
+  box-shadow: 0 0 10px rgba(130, 222, 255, 0.28);
+}
+
+.badge-warn {
+  color: var(--orange);
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: underline dotted var(--orange) 1px;
+  text-underline-offset: 3px;
+  background: rgba(255, 177, 127, 0.08);
+  border-radius: 8px;
+  padding: 3px 10px;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  border: 1px solid rgba(255, 177, 127, 0.4);
+  backdrop-filter: blur(8px);
+}
+
+.badge-ok {
+  color: var(--emerald);
+  font-weight: 700;
+  background: rgba(61, 235, 185, 0.08);
+  border-radius: 8px;
+  padding: 3px 10px;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  border: 1px solid rgba(61, 235, 185, 0.4);
+  backdrop-filter: blur(8px);
+}
+
+.itemmeta {
+  color: var(--sub);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.tiny {
+  font-size: 10px;
+  color: var(--accent);
+  letter-spacing: 0.04em;
+}
+
+.right {
+  text-align: right;
+}
+
+.center {
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.center-info {
+  font-size: 9px;
+  color: var(--accent);
+  display: inline-flex;
+  gap: 4px;
+}
+
+.tier {
+  font-family: 'Rajdhani', monospace;
+  text-align: center;
+  color: var(--gold);
+  font-size: 18px;
+  letter-spacing: 0.12em;
+  text-shadow: 0 0 12px rgba(255, 232, 163, 0.4);
+}
+
+input[type="number"] {
+  background: var(--panel2);
+  border: 1px solid var(--muted);
+  color: var(--text);
+  padding: 9px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="number"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 215, 255, 0.15);
+}
+
+::-webkit-scrollbar {
+  height: 8px;
+  width: 10px;
+  background: rgba(12, 18, 32, 0.92);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(60, 88, 140, 0.7);
+  border-radius: 8px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(92, 128, 190, 0.85);
+}
+
+.row > .center.mono {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  font-size: 14px;
+  min-height: 20px;
+  text-align: center;
+}
+
+.chip-icon-mask {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+  margin-right: 4px;
+  background-color: var(--text);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  transition: background-color 0.2s ease;
+}
+
+.chip.active .chip-icon-mask {
+  background-color: var(--chip-active-text);
+}
+
+@media (max-width: 960px) {
+  .row {
+    grid-template-columns: 0.8fr 2.2fr 1fr 4fr 1fr 2fr 2fr 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .row {
+    grid-template-columns: 1.2fr 2.4fr 1fr 3fr;
+    grid-template-areas:
+      'tag item tier stats'
+      'tag total total group'
+      'tag rank rank actions';
+  }
+}

--- a/beta.html
+++ b/beta.html
@@ -1,0 +1,501 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>D2 Armor Analyzer - By ErebusAres</title>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <link rel="stylesheet" href="beta.css" />
+
+</head>
+<body>
+  <div class="wrap">
+    <header class="panel" style="margin-bottom:16px">
+      <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:12px">
+        <div>
+          <h1>D2 Armor Analyzer</h1>
+          <div class="muted">♦ Upload your DIM CSV; dupes use top‑3 stat identities within ± tolerance. Exotics compare only against same‑name items.</div>
+          <div class="muted">♦ Click "Restore last" to reload the last uploaded CSV from this browser.</div>
+          <div class="muted">♦ Click "Copy ID" or A Group Badge to copy to clipboard.</div>
+        </div>
+        <div class="toolbar">
+          <input id="file" type="file" accept=".csv" />
+          <button class="btn" id="restoreBtn" aria-label="Restore last uploaded CSV">Restore last</button>
+          <button class="btn" id="clearBtn" aria-label="Clear all data">Clear</button>
+        </div>
+      </div>
+    </header>
+
+    <section class="panel" style="margin-bottom:16px">
+      <div class="filters">
+        <div class="line"><span class="label">Class</span><div id="classSeg" class="seg"></div></div>
+        <div class="line"><span class="label">Rarity</span><div id="raritySeg" class="seg"></div></div>
+        <div class="line"><span class="label">Slot</span><div id="slotSeg" class="seg"></div></div>
+        <div class="line"><span class="label">Dupes</span><div id="dupesSeg" class="seg"></div></div>
+        <div class="line"><span class="label">Tolerance</span><input id="tol" type="number" min="0" max="20" value="5" style="width:80px"/> <span class="muted">± top‑3 stat</span></div>
+      </div>
+    </section>
+
+    <section class="list">
+      <div class="row header">
+        <div class="center">Tag</div>
+        <div>Item</div>
+        <div class="center">Tier</div>
+        <div>Base Stats <div class="center-info">(Health, Melee, Grenade, Super, Class, Weapons)</div></div>
+        <div class="center">Total</div>
+        <div class="center">Group</div>
+        <div class="center">Rank</div>
+        <div class="right">Copy</div>
+      </div>
+      <div id="rows"></div>
+      <div id="empty" class="empty" style="display:none"><p>
+        No items yet — upload a DIM CSV or click Restore last.<br/><br/>
+
+        To export from DIM: <br/>
+        ♦ Go to https://app.destinyitemmanager.com/ and sign in. <br/>
+        ♦ Navigate to Organizer. <br/>
+        ♦ Select any class. <br/>
+        ♦ Click the "Armor.csv" button at the top right to download your armor data. <br/>
+        ♦ Upload the downloaded CSV file here. <br/>
+      </p></div>
+    </section>
+  </div>
+
+  <script>
+  // ====== Constants ======
+  const STAT_COLS = [
+    "Health (Base)",
+    "Melee (Base)",
+    "Grenade (Base)",
+    "Super (Base)",
+    "Class (Base)",
+    "Weapons (Base)"
+  ];
+  const STAT_ICONS = {
+    "Health (Base)":"https://www.bungie.net/common/destiny2_content/icons/717b8b218cc14325a54869bef21d2964.png",
+    "Melee (Base)":"https://www.bungie.net/common/destiny2_content/icons/fa534aca76d7f2d7e7b4ba4df4271b42.png",
+    "Grenade (Base)":"https://www.bungie.net/common/destiny2_content/icons/065cdaabef560e5808e821cefaeaa22c.png",
+    "Super (Base)":"https://www.bungie.net/common/destiny2_content/icons/585ae4ede9c3da96b34086fccccdc8cd.png",
+    "Class (Base)":"https://www.bungie.net/common/destiny2_content/icons/7eb845acb5b3a4a9b7e0b2f05f5c43f1.png",
+    "Weapons (Base)":"https://www.bungie.net/common/destiny2_content/icons/bc69675acdae9e6b9a68a02fb4d62e07.png"
+  };
+  const RARITY_ICONS = {
+    "Legendary": "https://www.bungie.net/common/destiny2_content/icons/f846f489c2a97afb289b357e431ecf8d.png",
+    "Exotic": "https://www.bungie.net/common/destiny2_content/icons/3e6a698e1a8a5fb446fdcbf1e63c5269.png"
+  };
+  const CLASS_OPTIONS = ["Warlock", "Hunter", "Titan"];
+  const SLOT_OPTIONS = ["All", "Helmet", "Gauntlets", "Chest Armor", "Leg Armor", "Class Item"];
+  const RARITY_OPTIONS = ["All", "Legendary", "Exotic"];  const DUPES_OPTIONS = ["All", "Only Dupes", "Only Same-Name"];
+  const classItemByClass = { Warlock: "Warlock Bond", Hunter: "Hunter Cloak", Titan: "Titan Mark" };
+  const TAG_EMOJIS = {
+    favorite: "❤️",
+    keep: "🏷️",
+    junk: "🚫",
+    infuse: "⚡",
+    archive: "📦"
+  };
+  const TAG_LABELS = {
+    favorite: "Favorite",
+    keep: "Keep",
+    junk: "Junk",
+    infuse: "Infuse",
+    archive: "Archive"
+  };
+  const CLASS_ICONS = {
+    "Warlock": "https://www.bungie.net/common/destiny2_content/icons/e4006d9a8fe167bd7e83193d7601c89a.png",
+    "Hunter":  "https://www.bungie.net/common/destiny2_content/icons/05e32a388d9a65a0ef59b2193eee2db4.png",
+    "Titan":   "https://www.bungie.net/common/destiny2_content/icons/46a19ddd00d0f6ca822230943103b54a.png"
+  };
+  const SLOT_ICONS = {
+    "Helmet": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/helmet.svg",
+    "Gauntlets": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/gloves.svg",
+    "Chest Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/chest.svg",
+    "Leg Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/boots.svg",
+    "Class Item": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/class.svg"
+  };
+  const ARMOR_ARCHETYPES = {
+    "Grenadier": "https://www.bungie.net/common/destiny2_content/icons/cbf4f03459ab2818a3d37b7362b2aa93.png", // Grenade, Super
+    "Paragon": "https://www.bungie.net/common/destiny2_content/icons/b5feb81f684d767d6212ca138f30b34c.png", // Super, Melee
+    "Specialist": "https://www.bungie.net/common/destiny2_content/icons/69731c603d7bcdd0a21b26c711d55f03.png", // Class, Weapons
+    "Brawler": "https://www.bungie.net/common/destiny2_content/icons/7bc3bc2bccdafc19dde31f867a06ee9f.png", // Melee, Health
+    "Bulwark": "https://www.bungie.net/common/destiny2_content/icons/cda905547dd9eac7a39e6e898f619bc5.png", // Health, Class
+    "Gunner": "https://www.bungie.net/common/destiny2_content/icons/15e3b3c25a6d4606dcb887cb67c915a1.png" // Weapons, Grenade
+  }
+  // ====== Helpers ======
+  const normId = (s) => (s ? String(s).trim().replace(/^"|"$/g, "") : "");
+  const normName = (s) => String(s || "").trim().toLowerCase();
+  const num = (v) => (v == null || v === "" ? 0 : Number(v));
+  function slotNumber(type){
+    if(type === "Helmet") return 1;
+    if(type === "Gauntlets") return 2;
+    if(type === "Chest Armor") return 3;
+    if(type === "Leg Armor") return 4;
+    if(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(type)) return 5;
+    return 9;
+  }
+  function starsLegendary(t){ const n=num(t); if(n>=75) return "★★★★★"; if(n===74) return "★★★★☆"; if(n===73) return "★★★☆☆"; if(n===72) return "★★☆☆☆"; if(n===71) return "★☆☆☆☆"; return "💩"; }
+  function starsExotic(t){ const n=num(t); if(n>=63) return "★★★★★"; if(n===62) return "★★★★☆"; if(n===61) return "★★★☆☆"; if(n===60) return "★★☆☆☆"; if(n===59) return "★☆☆☆☆"; return "💩"; }
+  function statColorCls(v){ if(v>=30) return "stat-cyan"; if(v>=24) return "stat-green"; if(v>=15) return "stat-yellow"; return "stat-red"; }
+  function top3Entries(item){
+    const arr = STAT_COLS.map(k => ({ name:k, value:num(item[k]) }));
+    arr.sort((a,b)=> (b.value - a.value) || a.name.localeCompare(b.name));
+    return arr.slice(0,3);
+  }
+  function similarTop3(a,b,tol){
+    const ta = top3Entries(a), tb = top3Entries(b);
+    for(let i=0;i<3;i++){
+      if(ta[i].name !== tb[i].name) return false;
+      if(Math.abs(ta[i].value - tb[i].value) > tol) return false;
+    }
+    return true;
+  }
+  function rankScore(rank){ if(!rank) return -1; const stars=(rank.match(/★/g)||[]).length; if(stars>0) return stars; return 0; }
+  async function copyTextSafe(text){
+    try{
+      if(navigator.clipboard && window.isSecureContext){ await navigator.clipboard.writeText(text); return true; }
+      throw new Error('clipboard api not available');
+    }catch(e){
+      try{ const ta=document.createElement('textarea'); ta.value=text; ta.setAttribute('readonly',''); ta.style.position='fixed'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); const ok=document.execCommand('copy'); document.body.removeChild(ta); return ok; }catch(e2){ alert('Copy failed: '+e2); return false; }
+    }
+  }
+
+  // ====== State & Storage ======
+  let STATE = { 
+    rows:[], 
+    classFilter:'Warlock', 
+    slotFilter:'All', 
+    rarityFilter:'All', 
+    tol:5, 
+    dupesFilter:'All' // NEW
+  };
+  const LS_KEY = 'd2_armor_rows_v1';
+  function saveRows(){ try{ localStorage.setItem(LS_KEY, JSON.stringify(STATE.rows)); }catch(_){} }
+  function loadRows(){ try{ const s=localStorage.getItem(LS_KEY); if(!s) return null; return JSON.parse(s); }catch(_){ return null; } }
+
+  // ====== Filters UI ======
+  function makeSeg(containerId, options, key){
+  const el = document.getElementById(containerId); if(!el) return; el.innerHTML='';
+  options.forEach(opt => {
+    const btn = document.createElement('button');
+    btn.className = 'chip' + (STATE[key]===opt ? ' active' : '');
+    let label = opt;
+    // Add icons for class, rarity, and slot filters
+    if (containerId === 'classSeg' && CLASS_ICONS[opt]) {
+      label = `<span class="chip-icon-mask" style="mask-image:url('${CLASS_ICONS[opt]}');-webkit-mask-image:url('${CLASS_ICONS[opt]}');"></span>${opt}`;
+    }
+    if (containerId === 'raritySeg' && RARITY_ICONS[opt]) {
+      label = `<img src="${RARITY_ICONS[opt]}" alt="${opt}" title="${opt}" class="chip-icon rarity" style="height:1em;vertical-align:middle;margin-right:4px;">${opt}`;
+    }
+    if (containerId === 'slotSeg' && SLOT_ICONS[opt]) {
+      label = `<span class="chip-icon-mask" style="mask-image:url('${SLOT_ICONS[opt]}');-webkit-mask-image:url('${SLOT_ICONS[opt]}');"></span>${opt}`;
+    }
+    btn.innerHTML = (STATE[key]===opt? '● ' : '○ ') + label;
+    btn.addEventListener('click', ()=>{ STATE[key]=opt; render(); makeSeg(containerId, options, key); });
+    el.appendChild(btn);
+  });
+}
+  function initFilters(){
+    makeSeg('classSeg', CLASS_OPTIONS, 'classFilter');
+    makeSeg('raritySeg', RARITY_OPTIONS, 'rarityFilter');
+    makeSeg('slotSeg',   SLOT_OPTIONS,   'slotFilter');
+    makeSeg('dupesSeg',  DUPES_OPTIONS,  'dupesFilter'); // NEW
+  }
+
+  // ====== Data selection ======
+  function getFiltered(){
+  const expected = classItemByClass[STATE.classFilter];
+  // Always group on the full set for dupe logic
+  let baseFiltered = STATE.rows.filter(r =>
+    (STATE.classFilter ? r.Equippable === STATE.classFilter : true) &&
+    (STATE.slotFilter==='All' ? true : STATE.slotFilter==='Class Item' ? r.Type===expected : r.Type===STATE.slotFilter) &&
+    (STATE.rarityFilter==='All' ? true : r.Rarity === STATE.rarityFilter)
+  );
+  // Get all grouped rows for this filtered set
+  const grouped = clusterRows(baseFiltered);
+
+  if (STATE.dupesFilter === "Only Dupes") {
+    // Show only items in any dupe group (Dupe_Group !== "X")
+    return grouped.filter(r => r.Dupe_Group && r.Dupe_Group !== "X");
+  } else if (STATE.dupesFilter === "Only Same-Name") {
+    // Show only dupe groups where all items share the same name
+    // 1. Find all dupe groups
+    const dupeGroups = {};
+    for (const r of grouped) {
+      if (r.Dupe_Group && r.Dupe_Group !== "X") {
+        const key = `${r.GroupKey}::${r.Dupe_Group}`;
+        if (!dupeGroups[key]) dupeGroups[key] = [];
+        dupeGroups[key].push(r);
+      }
+    }
+    // 2. Keep only groups where all items have the same normalized name
+    const validIds = new Set();
+    for (const group of Object.values(dupeGroups)) {
+      const names = new Set(group.map(r => normName(r.Name)));
+      if (names.size === 1) {
+        for (const r of group) validIds.add(r.Id);
+      }
+    }
+    return grouped.filter(r => validIds.has(r.Id));
+  }
+  // Default: show all
+  return grouped;
+}
+
+  // ====== Grouping & Sorting ======
+  function clusterRows(filtered){
+    const byKey = new Map();
+    for(const r of filtered){
+      const k = r.Rarity==='Exotic' ? `${r.Type}|${normName(r.Name)}` : r.Type; // exotics cluster by name
+      if(!byKey.has(k)) byKey.set(k,[]);
+      byKey.get(k).push({...r});
+    }
+    const out=[]; const A='ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    for(const [key,items] of byKey){
+      const assigned = Array(items.length).fill(false);
+      const rawGroups = [];
+      for(let i=0;i<items.length;i++){
+        if(assigned[i]) continue;
+        const grp=[i]; assigned[i]=true;
+        for(let j=i+1;j<items.length;j++){
+          if(assigned[j]) continue;
+          if(STATE.sameNameOnly && normName(items[i].Name)!==normName(items[j].Name)) continue;
+          if(similarTop3(items[i],items[j],STATE.tol)){ grp.push(j); assigned[j]=true; }
+        }
+        rawGroups.push(grp);
+      }
+      // Order groups by best total first, then id to stabilize
+      rawGroups.sort((g1,g2)=>{
+        const best1 = Math.max(...g1.map(ix=>num(items[ix]["Total (Base)"])));
+        const best2 = Math.max(...g2.map(ix=>num(items[ix]["Total (Base)"])));
+        if(best1!==best2) return best2-best1;
+        return String(items[g1[0]].Id).localeCompare(String(items[g2[0]].Id));
+      });
+      const isExoticKey = key.includes('|');
+      let letterIdx = 0;
+      for(const grp of rawGroups){
+        const first = items[grp[0]];
+        let label = 'X';
+        if(grp.length > 1) {
+          const letter = A[Math.min(letterIdx, A.length-1)];
+          if(isExoticKey) {
+            label = `⚠️🟡${slotNumber(first.Type)}${letter}`;
+          } else {
+            label = `⚠️${slotNumber(first.Type)}${letter}`;
+          }
+          letterIdx++;
+        }
+        for(const gi of grp){
+          const it = items[gi];
+          const rank = it.Rarity==='Exotic' ? starsExotic(it["Total (Base)"]) : starsLegendary(it["Total (Base)"]); 
+          out.push({ 
+            ...it, 
+            GroupKey:key, 
+            Dupe_Group:label, 
+            Rank:rank, 
+            RankScore:rankScore(rank), 
+            Is_Dupe: label!=='X',
+            Is_Dupe_Exotic: (it.Rarity==='Exotic' && label!=='X') // <-- Add this flag
+          });
+        }
+      }
+    }
+    // Final sort: 
+out.sort((a, b) => {
+  // 1. Slot order
+  const sa = slotNumber(a.Type), sb = slotNumber(b.Type);
+  if (sa !== sb) return sa - sb;
+
+  // 2. Legendary before Exotic
+  const ra = a.Rarity === "Legendary" ? 0 : 1;
+  const rb = b.Rarity === "Legendary" ? 0 : 1;
+  if (ra !== rb) return ra - rb;
+
+  // 3. Dupe group first within each rarity
+  const da = a.Dupe_Group !== "X";
+  const db = b.Dupe_Group !== "X";
+  if (da !== db) return db - da; // true first
+
+  // 4. For dupe groups: group label, then rank desc, then total desc, then id
+  if (da && db) {
+    // Group by group key (for exotics, this is name+type)
+    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
+    if (a.Dupe_Group !== b.Dupe_Group) return String(a.Dupe_Group).localeCompare(String(b.Dupe_Group));
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // 5. For exotics: after dupe groups, show non-grouped exotics of same name below groups
+  if (a.Rarity === "Exotic" && b.Rarity === "Exotic") {
+    // GroupKey for exotics is type|name
+    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
+    // Non-grouped exotics of same name (Dupe_Group === "X") come after grouped
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // 6. For legendaries: non-dupes by name, then rank desc, then total desc, then id
+  if (a.Rarity === "Legendary" && b.Rarity === "Legendary") {
+    const na = String(a.Name).toLowerCase(), nb = String(b.Name).toLowerCase();
+    if (na !== nb) return na.localeCompare(nb);
+    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
+    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
+    if (tb !== ta) return tb - ta;
+    return String(a.Id).localeCompare(String(b.Id));
+  }
+
+  // Fallback: by id
+  return String(a.Id).localeCompare(String(b.Id));
+});
+    return out;
+  }
+
+  // ====== Render ======
+  function render(){
+  updateShadowColor(); 
+    const tolEl=document.getElementById('tol'); if(tolEl) tolEl.value = STATE.tol;
+    initFilters();
+
+    const grouped = getFiltered();
+
+    // Build group->ids for copy-all
+    const groupToIds = new Map();
+    for(const it of grouped){ if(it.Dupe_Group==='X') continue; const key=`${it.GroupKey||''}::${it.Dupe_Group}`; if(!groupToIds.has(key)) groupToIds.set(key,[]); groupToIds.get(key).push(normId(it.Id)); }
+
+    const host=document.getElementById('rows');
+    const empty=document.getElementById('empty');
+    host.innerHTML='';
+    if(grouped.length===0){ if(empty) empty.style.display='block'; return; } else { if(empty) empty.style.display='none'; }
+
+    let lastGroup = null;
+    let altToggle = false;
+    for(const it of grouped){
+      // Alternate shade when group changes (by Dupe_Group label)
+      if (it.Dupe_Group !== lastGroup) {
+        altToggle = !altToggle;
+        lastGroup = it.Dupe_Group;
+      }
+      const row=document.createElement('div');
+      row.className = 'row item ' + (altToggle ? 'altA' : 'altB');
+      // Tag emoji (DIM tag)
+      const cTag = document.createElement('div');
+      cTag.className = 'center';
+      const tag = (it.Tag || '').toLowerCase();
+      cTag.textContent = TAG_EMOJIS[tag] || '';
+      cTag.title = TAG_LABELS[tag] || '';
+      // Item
+      const cItem=document.createElement('div');
+      cItem.innerHTML=`<div style="font-weight:700">${it.Name}</div>
+        <div class="itemmeta">
+          ${(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(it.Type)?"Class Item":it.Type)}
+          • ${it.Equippable}
+          • <img src="${RARITY_ICONS[it.Rarity] || ''}" alt="${it.Rarity}" title="${it.Rarity}" style="height:1em;vertical-align:middle;">
+        </div>
+        <div class="tiny mono">${normId(it.Id)}</div>`;
+      // Tier
+      const cTier=document.createElement('div'); 
+      cTier.className='tier'; 
+      const tVal = Number.isFinite(it.Tier) ? Number(it.Tier) : 0; 
+      cTier.textContent = '♦'.repeat(Math.max(1, Math.min(5, tVal)));
+      // Stats chips
+      const cStats=document.createElement('div'); cStats.className='chips';
+      for(const k of STAT_COLS){
+        const pill=document.createElement('span'); pill.className=`chipStat ${statColorCls(it[k])}`; pill.title=k.replace(' (Base)','');
+        const img=document.createElement('img'); img.className='stat-ico'; img.alt=k; img.src=STAT_ICONS[k]||''; if(img.src) pill.appendChild(img);
+        const strong=document.createElement('strong'); strong.className='mono'; strong.textContent=String(it[k]||0); pill.appendChild(strong);
+        cStats.appendChild(pill);
+      }
+      // Total
+      const cTotal=document.createElement('div'); cTotal.className='center'; cTotal.style.fontWeight='700'; cTotal.textContent=String(it["Total (Base)"]||0);
+      // Group (click to copy all group ids)
+      const cGroup=document.createElement('div'); cGroup.className='center';
+      if(it.Dupe_Group!=='X'){
+        const label = it.Dupe_Group;
+        const key=`${it.GroupKey||''}::${it.Dupe_Group}`;
+        const list=(groupToIds.get(key)||[]).map(id=>`id:${id}`).join(' or ');
+        const span=document.createElement('span'); 
+        span.className='badge-warn'; 
+        span.title='Click to copy all IDs in this dupe group';
+
+        // PATCH: replace 🟡 in label with a rarity <img> for Exotic groups by assembling DOM nodes
+        // We keep label text (which might contain ⚠️🟡1A, etc.) but we render the icon instead of the 🟡
+        // Detect exotic dupe groups using the label pattern OR the item's rarity
+        const exoticGroup = /🟡/.test(label) || it.Rarity === 'Exotic';
+        if (exoticGroup && RARITY_ICONS[it.Rarity]) {
+          // Split off the visible prefix before slot/letter (remove the emoji if present)
+          const textNoYellow = label.replace('🟡','');
+          // Optional: if the label still includes the ⚠️, we keep it in text
+          // Prepend the icon after ⚠️
+          const m = textNoYellow.match(/^(⚠️)?(.*)$/);
+          const prefix = (m && m[1]) ? '⚠️' : '';
+          const rest = (m && m[2]) ? m[2] : textNoYellow;
+          if (prefix) span.append(prefix);
+
+          const img = new Image();
+          img.src = RARITY_ICONS[it.Rarity];
+          img.alt = it.Rarity;
+          img.title = it.Rarity;
+          img.style.height = '1em';
+          img.style.verticalAlign = 'middle';
+          img.style.marginRight = '4px';
+          span.appendChild(img);
+
+          span.append(rest);
+        } else {
+          // Fallback: plain text
+          span.append(label);
+        }
+        span.addEventListener('click', async ()=>{ const ok=await copyTextSafe(list); if(!ok) alert('Copy failed'); });
+        cGroup.appendChild(span);
+      } else {
+        cGroup.innerHTML = `<span class='badge-ok'>✅</span>`;
+      }
+      // Rank
+      const cRank=document.createElement('div'); cRank.className='center'; cRank.textContent=it.Rank||'';
+      // Copy single id
+      const cCopy=document.createElement('div'); cCopy.className='right';
+      const btn=document.createElement('button'); btn.className='btn'; btn.textContent='Copy id';
+      btn.addEventListener('click', async ()=>{ const ok=await copyTextSafe(`id:${normId(it.Id)}`); btn.textContent= ok? 'Copied!' : 'Copy id'; setTimeout(()=> btn.textContent='Copy id', 1200); });
+      cCopy.appendChild(btn);
+
+      row.append(cTag,cItem,cTier,cStats,cTotal,cGroup,cRank,cCopy);
+      host.appendChild(row);
+    }
+  }
+
+  // ====== Events ======
+document.getElementById('file').addEventListener('change', (e)=>{
+    const f=e.target.files?.[0]; if(!f) return;
+  Papa.parse(f,{header:true, skipEmptyLines:true, complete:(res)=>{
+    const data=res.data||[];
+    STATE.rows = data.map(r=>{ const x={...r}; for(const k of [...STAT_COLS,'Total (Base)','Tier']) { if(x[k]!==undefined) { const n = num(x[k]); x[k] = Number.isFinite(n) ? n : 0; } } x.Id=normId(x.Id); return x; });
+    saveRows();
+    render();
+    document.getElementById('file').value = '';
+  }});
+});
+document.getElementById('restoreBtn').addEventListener('click', ()=>{ const rows=loadRows(); if(rows&&Array.isArray(rows)){ STATE.rows=rows; render(); } else { alert('No saved CSV found in this browser. Upload a DIM CSV first.'); } });
+  document.getElementById('clearBtn').addEventListener('click', ()=>{ STATE.rows=[]; localStorage.removeItem(LS_KEY); document.getElementById('file').value=''; render(); });
+  document.getElementById('tol').addEventListener('input', (e)=>{ const v=Number(e.target.value); STATE.tol = isFinite(v)? v: STATE.tol; render(); });
+
+  function updateShadowColor() {
+  const root = document.documentElement;
+  if (STATE.rarityFilter === "Legendary") {
+    root.style.setProperty('--shadow', 'var(--shadow-purple)');
+  } else if (STATE.rarityFilter === "Exotic") {
+    root.style.setProperty('--shadow', 'var(--shadow-gold)');
+  } else {
+    root.style.setProperty('--shadow', 'var(--shadow-base)');
+  }
+}
+
+  // Initial
+  const cached = loadRows(); if(cached){ STATE.rows=cached; }
+  render();
+  updateShadowColor();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- duplicate the existing analyzer markup into `beta.html` and load a separate stylesheet for the beta experience
- craft `beta.css` with an Edge of Fate inspired dark theme, refreshed typography, gradients, and hover states while keeping the original layout intact

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68c87826e06c832d9557869a16934d1b