### PR TITLE
Streamline Bungie auth and auto-sync armor

### DIFF
--- a/beta.css
+++ b/beta.css
@@ -143,6 +143,128 @@ h1::after {
   flex: 1 1 auto;
 }
 
+.panel-auth {
+  margin-bottom: 16px;
+}
+
+.panel-auth h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.auth-header {
+  margin-bottom: 12px;
+}
+
+.auth-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.auth-label {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.auth-field input,
+.auth-field select {
+  background: var(--panel2);
+  border: 1px solid var(--muted);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: var(--text);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-field input:focus,
+.auth-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 215, 255, 0.15);
+}
+
+.auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.auth-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.auth-membership {
+  margin-bottom: 12px;
+}
+
+.auth-note {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.code-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: 'Fira Code', 'Source Code Pro', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: var(--panel2);
+  border: 1px solid var(--muted);
+  color: var(--text);
+  word-break: break-all;
+}
+
+.auth-status {
+  margin-top: 6px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  min-height: 18px;
+}
+
+.auth-status.status-ok {
+  color: var(--stat-green);
+}
+
+.auth-status.status-error {
+  color: #ff9ca1;
+}
+
+.auth-status.status-loading {
+  color: var(--accent);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  filter: grayscale(0.3);
+}
+
 .toolbar {
   display: flex;
   flex-direction: column;
@@ -356,6 +478,19 @@ button.tool-card {
   border-color: var(--accent);
   box-shadow: var(--glow);
   transform: translateY(-1px);
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, rgba(124, 215, 255, 0.4), rgba(159, 133, 255, 0.28));
+  color: var(--chip-active-text);
+  border-color: rgba(124, 215, 255, 0.8);
+  box-shadow: var(--glow);
+}
+
+.btn-primary:hover {
+  background: linear-gradient(120deg, rgba(124, 215, 255, 0.65), rgba(159, 133, 255, 0.45));
+  color: var(--chip-active-text);
+  border-color: var(--accent);
 }
 
 .filters {

--- a/beta.html
+++ b/beta.html
@@ -64,6 +64,28 @@
       </div>
     </header>
 
+    <section class="panel panel-auth" id="bungiePanel">
+      <div class="auth-header">
+        <h2>Connect with Bungie</h2>
+        <p class="muted">Sign in with your Bungie account to pull armor automatically, or continue using CSV uploads.</p>
+      </div>
+      <div class="auth-buttons">
+        <button id="bungieLogin" type="button" class="btn btn-primary">Sign in with Bungie</button>
+        <button id="bungieRefresh" type="button" class="btn">Refresh armor</button>
+        <button id="bungieLogout" type="button" class="btn">Sign out</button>
+      </div>
+      <div id="membershipSelectWrap" class="auth-membership" style="display:none">
+        <label class="auth-field">
+          <span class="auth-label">Active profile</span>
+          <select id="membershipSelect"></select>
+        </label>
+      </div>
+      <div class="auth-note muted">Using the ErebusAres Bungie application (Client ID 50794) registered for this site.</div>
+      <div class="auth-note muted">OAuth redirect: <code class="code-inline" id="bungieRedirectUri"></code></div>
+      <div class="auth-note muted">Tokens are stored locally in this browser only.</div>
+      <div id="bungieStatus" class="auth-status muted" aria-live="polite"></div>
+    </section>
+
     <section class="panel" style="margin-bottom:16px">
       <div class="filters">
         <div class="line"><span class="label">Class</span><div id="classSeg" class="seg"></div></div>
@@ -159,6 +181,56 @@
     "Bulwark": "https://www.bungie.net/common/destiny2_content/icons/cda905547dd9eac7a39e6e898f619bc5.png", // Health, Class
     "Gunner": "https://www.bungie.net/common/destiny2_content/icons/15e3b3c25a6d4606dcb887cb67c915a1.png" // Weapons, Grenade
   }
+  const CLASS_BY_TYPE = { 0: "Titan", 1: "Hunter", 2: "Warlock", 3: "Unknown", 4: "Any" };
+  const ARMOR_BUCKET_HASH_TO_TYPE = {
+    3448274439: "Helmet",
+    3551918588: "Gauntlets",
+    14239492: "Chest Armor",
+    20886954: "Leg Armor",
+    1585787867: "Class Item"
+  };
+  const STAT_HASH_TO_LABEL = {
+    392767087: "Health (Base)",
+    4244567218: "Melee (Base)",
+    1735777505: "Grenade (Base)",
+    144602215: "Super (Base)",
+    1943323491: "Class (Base)",
+    2996146975: "Weapons (Base)"
+  };
+  const MEMBERSHIP_TYPE_NAMES = {
+    1: "Xbox",
+    2: "PlayStation",
+    3: "Steam",
+    4: "Blizzard",
+    5: "Stadia",
+    6: "Epic",
+    7: "Demon",
+    10: "Tiger",
+    254: "BungieNet"
+  };
+  const BUNGIE_CONFIG_STORAGE = 'd2aa_bungie_cfg_v1';
+  const BUNGIE_TOKEN_STORAGE = 'd2aa_bungie_tokens_v1';
+  const BUNGIE_STATE_STORAGE = 'd2aa_bungie_state_v1';
+  const BUNGIE_VERIFIER_STORAGE = 'd2aa_bungie_verifier_v1';
+  const BUNGIE_RETURN_STORAGE = 'd2aa_bungie_return_v1';
+  const BUNGIE_COMPONENTS = '100,102,200,201,205,300,304';
+  const BUNGIE_OAUTH_URL = 'https://www.bungie.net/en/OAuth/Authorize';
+  const BUNGIE_TOKEN_URL = 'https://www.bungie.net/Platform/App/OAuth/Token/';
+  const BUNGIE_API_ROOT = 'https://www.bungie.net/Platform';
+  const BUNGIE_REDIRECT_URI = (() => {
+    try {
+      const { origin, pathname } = window.location;
+      if (!origin || origin === 'null') {
+        return 'https://erebusares.github.io/D2AA/beta.html';
+      }
+      return `${origin}${pathname}`;
+    } catch (err) {
+      console.warn('Falling back to default Bungie redirect URI', err);
+      return 'https://erebusares.github.io/D2AA/beta.html';
+    }
+  })();
+  const BUNGIE_DEFAULT_API_KEY = '96e154014bdd44c0a537e482709b7473';
+  const BUNGIE_DEFAULT_CLIENT_ID = '50794';
   // ====== Helpers ======
   const normId = (s) => (s ? String(s).trim().replace(/^"|"$/g, "") : "");
   const normName = (s) => String(s || "").trim().toLowerCase();
@@ -198,15 +270,31 @@
   }
 
   // ====== State & Storage ======
-  let STATE = { 
-    rows:[], 
-    classFilter:'Warlock', 
-    slotFilter:'All', 
-    rarityFilter:'All', 
-    tol:5, 
+  let STATE = {
+    rows:[],
+    classFilter:'Warlock',
+    slotFilter:'All',
+    rarityFilter:'All',
+    tol:5,
     dupesFilter:'All' // NEW
   };
   const LS_KEY = 'd2_armor_rows_v1';
+  let bungieConfig = loadBungieConfig();
+  let bungieTokens = loadBungieTokens();
+  let bungieMemberships = [];
+  let bungieIsFetching = false;
+  let bungieAutoLoadedOnce = false;
+  const manifestCache = {
+    inventoryItem: new Map(),
+    bucket: new Map()
+  };
+  let bungieStatusEl = null;
+  let bungieRedirectUriEl = null;
+  let bungieMembershipSelect = null;
+  let bungieMembershipWrap = null;
+  let bungieLoginBtn = null;
+  let bungieRefreshBtn = null;
+  let bungieLogoutBtn = null;
   function saveRows(){ try{ localStorage.setItem(LS_KEY, JSON.stringify(STATE.rows)); }catch(_){} }
   function loadRows(){ try{ const s=localStorage.getItem(LS_KEY); if(!s) return null; return JSON.parse(s); }catch(_){ return null; } }
 
@@ -279,6 +367,639 @@
   return grouped;
 }
 
+  // ====== Bungie API Integration ======
+  function getDefaultTokenState(){
+    return {
+      accessToken:null,
+      refreshToken:null,
+      accessTokenExpires:0,
+      refreshTokenExpires:0,
+      tokenType:'Bearer',
+      membershipId:null,
+      membershipType:null
+    };
+  }
+
+  function loadBungieConfig(){
+    const defaults = {
+      apiKey: BUNGIE_DEFAULT_API_KEY,
+      clientId: BUNGIE_DEFAULT_CLIENT_ID,
+      membershipId: null,
+      membershipType: null
+    };
+    try{
+      const raw = localStorage.getItem(BUNGIE_CONFIG_STORAGE);
+      if(!raw) return { ...defaults };
+      const parsed = JSON.parse(raw);
+      const merged = { ...defaults, ...parsed };
+      if(!merged.apiKey) merged.apiKey = BUNGIE_DEFAULT_API_KEY;
+      if(!merged.clientId) merged.clientId = BUNGIE_DEFAULT_CLIENT_ID;
+      return merged;
+    }catch(err){
+      console.warn('Failed to parse Bungie config', err);
+      return { ...defaults };
+    }
+  }
+
+  function saveBungieConfig(){
+    try{
+      localStorage.setItem(BUNGIE_CONFIG_STORAGE, JSON.stringify(bungieConfig));
+    }catch(err){
+      console.warn('Failed to persist Bungie config', err);
+    }
+  }
+
+  function ensureBungieConfigDefaults(){
+    if(!bungieConfig) bungieConfig = loadBungieConfig();
+    const trimmedKey = (bungieConfig.apiKey || '').trim();
+    const trimmedClient = (bungieConfig.clientId || '').toString().trim();
+    if(!trimmedKey){
+      bungieConfig.apiKey = BUNGIE_DEFAULT_API_KEY;
+    }else{
+      bungieConfig.apiKey = trimmedKey;
+    }
+    if(!trimmedClient){
+      bungieConfig.clientId = BUNGIE_DEFAULT_CLIENT_ID;
+    }else{
+      bungieConfig.clientId = trimmedClient;
+    }
+  }
+
+  function loadBungieTokens(){
+    const defaults = getDefaultTokenState();
+    try{
+      const raw = localStorage.getItem(BUNGIE_TOKEN_STORAGE);
+      if(!raw) return { ...defaults };
+      const parsed = JSON.parse(raw);
+      return { ...defaults, ...parsed };
+    }catch(err){
+      console.warn('Failed to load Bungie tokens', err);
+      return { ...defaults };
+    }
+  }
+
+  function saveBungieTokens(){
+    try{
+      if(!bungieTokens || (!bungieTokens.accessToken && !bungieTokens.refreshToken)){
+        localStorage.removeItem(BUNGIE_TOKEN_STORAGE);
+        return;
+      }
+      localStorage.setItem(BUNGIE_TOKEN_STORAGE, JSON.stringify(bungieTokens));
+    }catch(err){
+      console.warn('Failed to persist Bungie tokens', err);
+    }
+  }
+
+  function clearBungieTokens(showMessage){
+    bungieTokens = getDefaultTokenState();
+    bungieMemberships = [];
+    bungieAutoLoadedOnce = false;
+    localStorage.removeItem(BUNGIE_TOKEN_STORAGE);
+    renderMembershipOptions();
+    updateBungieUI();
+    if(showMessage){
+      setBungieStatus('Signed out. You can still upload CSV files manually.', 'info');
+    }
+  }
+
+  function updateBungieUI(){
+    const hasConfig = Boolean((bungieConfig?.apiKey || '').trim() && (bungieConfig?.clientId || '').trim());
+    const hasRefresh = Boolean(bungieTokens?.refreshToken);
+    const refreshValid = hasRefresh && Date.now() < ((bungieTokens.refreshTokenExpires || 0) - 60000);
+    const signedIn = hasRefresh && refreshValid;
+    if(bungieLoginBtn) bungieLoginBtn.disabled = bungieIsFetching || !hasConfig;
+    if(bungieRefreshBtn) bungieRefreshBtn.disabled = bungieIsFetching || !signedIn || !hasConfig;
+    if(bungieLogoutBtn) bungieLogoutBtn.disabled = bungieIsFetching || !hasRefresh;
+    if(bungieMembershipWrap){
+      bungieMembershipWrap.style.display = bungieMemberships.length ? 'block' : 'none';
+    }
+  }
+
+  function renderMembershipOptions(){
+    if(!bungieMembershipSelect || !bungieMembershipWrap){
+      return;
+    }
+    bungieMembershipSelect.innerHTML = '';
+    if(!bungieMemberships.length){
+      bungieMembershipWrap.style.display = 'none';
+      return;
+    }
+    bungieMembershipWrap.style.display = 'block';
+    let hasSelection = false;
+    for(const mem of bungieMemberships){
+      const opt = document.createElement('option');
+      opt.value = `${mem.membershipType}:${mem.membershipId}`;
+      opt.textContent = mem.label;
+      if(String(bungieConfig?.membershipType) === String(mem.membershipType) && String(bungieConfig?.membershipId) === String(mem.membershipId)){
+        opt.selected = true;
+        hasSelection = true;
+      }
+      bungieMembershipSelect.appendChild(opt);
+    }
+    if(!hasSelection && bungieMembershipSelect.options.length > 0){
+      bungieMembershipSelect.selectedIndex = 0;
+      const [type,id] = bungieMembershipSelect.value.split(':');
+      bungieConfig.membershipType = Number(type);
+      bungieConfig.membershipId = id;
+      saveBungieConfig();
+    }
+    updateBungieUI();
+  }
+
+  function formatMembershipLabel(mem){
+    const code = mem?.bungieGlobalDisplayNameCode != null ? String(mem.bungieGlobalDisplayNameCode).padStart(4,'0') : '';
+    const baseName = mem?.bungieGlobalDisplayName ? `${mem.bungieGlobalDisplayName}${code ? '#' + code : ''}` : (mem?.displayName || mem?.lastSeenDisplayName || 'Guardian');
+    const platform = MEMBERSHIP_TYPE_NAMES[mem?.membershipType] || `Type ${mem?.membershipType}`;
+    return `${baseName} • ${platform}`;
+  }
+
+  function getSelectedMembership(){
+    if(!bungieMemberships.length) return null;
+    const found = bungieMemberships.find(mem => String(mem.membershipType) === String(bungieConfig?.membershipType) && String(mem.membershipId) === String(bungieConfig?.membershipId));
+    if(found) return found;
+    const fallback = bungieMemberships[0];
+    if(fallback){
+      bungieConfig.membershipType = fallback.membershipType;
+      bungieConfig.membershipId = fallback.membershipId;
+      saveBungieConfig();
+      renderMembershipOptions();
+    }
+    return fallback || null;
+  }
+
+  function setBungieStatus(message, type='info'){
+    if(!bungieStatusEl) return;
+    bungieStatusEl.textContent = message || '';
+    bungieStatusEl.classList.remove('status-ok','status-error','status-loading');
+    const isInfo = !message || type === 'info';
+    bungieStatusEl.classList.toggle('muted', isInfo);
+    if(type === 'ok') bungieStatusEl.classList.add('status-ok');
+    else if(type === 'error') bungieStatusEl.classList.add('status-error');
+    else if(type === 'loading') bungieStatusEl.classList.add('status-loading');
+  }
+
+  const PKCE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+
+  function randomString(length){
+    const array = new Uint8Array(length);
+    if(window.crypto?.getRandomValues){
+      window.crypto.getRandomValues(array);
+    }else{
+      for(let i=0;i<length;i++){ array[i] = Math.floor(Math.random()*PKCE_CHARSET.length); }
+    }
+    let out = '';
+    for(let i=0;i<length;i++){
+      out += PKCE_CHARSET[array[i] % PKCE_CHARSET.length];
+    }
+    return out;
+  }
+
+  function base64UrlEncode(buffer){
+    let binary = '';
+    const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+    for(let i=0;i<bytes.byteLength;i++){
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  }
+
+  async function createCodeChallenge(verifier){
+    if(!window.crypto?.subtle){
+      throw new Error('Browser crypto API is not available for PKCE.');
+    }
+    const data = new TextEncoder().encode(verifier);
+    const digest = await window.crypto.subtle.digest('SHA-256', data);
+    return base64UrlEncode(new Uint8Array(digest));
+  }
+
+  async function startBungieAuth(){
+    try{
+      ensureBungieConfigDefaults();
+      if(!bungieConfig?.clientId || !bungieConfig?.apiKey){
+        setBungieStatus('Bungie credentials are missing. Refresh and try again.', 'error');
+        return;
+      }
+      saveBungieConfig();
+      const verifier = randomString(64);
+      const challenge = await createCodeChallenge(verifier);
+      const state = randomString(32);
+      const returnUrl = window.location.href.split('#')[0];
+      const redirectUri = BUNGIE_REDIRECT_URI || returnUrl;
+      sessionStorage.setItem(BUNGIE_VERIFIER_STORAGE, verifier);
+      sessionStorage.setItem(BUNGIE_STATE_STORAGE, state);
+      sessionStorage.setItem(BUNGIE_RETURN_STORAGE, returnUrl);
+      const url = new URL(BUNGIE_OAUTH_URL);
+      url.searchParams.set('client_id', bungieConfig.clientId);
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('state', state);
+      url.searchParams.set('code_challenge', challenge);
+      url.searchParams.set('code_challenge_method', 'S256');
+      if(redirectUri){
+        url.searchParams.set('redirect_uri', redirectUri);
+      }
+      setBungieStatus('Redirecting to Bungie for sign-in…', 'loading');
+      window.location.href = url.toString();
+    }catch(err){
+      console.error(err);
+      setBungieStatus('Unable to start Bungie sign-in: ' + (err?.message || err), 'error');
+    }
+  }
+
+  function cleanOAuthParams(){
+    const storedReturn = sessionStorage.getItem(BUNGIE_RETURN_STORAGE);
+    if(storedReturn){
+      window.history.replaceState({}, document.title, storedReturn);
+      return;
+    }
+    try{
+      const current = new URL(window.location.href);
+      current.searchParams.delete('code');
+      current.searchParams.delete('state');
+      current.searchParams.delete('error');
+      current.searchParams.delete('error_description');
+      window.history.replaceState({}, document.title, current.toString());
+    }catch(err){
+      console.warn('Failed to clean OAuth params', err);
+    }
+  }
+
+  async function handleOAuthRedirect(){
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get('error');
+    if(error){
+      cleanOAuthParams();
+      setBungieStatus(`Authorization failed: ${error}`, 'error');
+      sessionStorage.removeItem(BUNGIE_VERIFIER_STORAGE);
+      sessionStorage.removeItem(BUNGIE_STATE_STORAGE);
+      sessionStorage.removeItem(BUNGIE_RETURN_STORAGE);
+      return;
+    }
+    const code = params.get('code');
+    if(!code) return;
+    const state = params.get('state');
+    const storedState = sessionStorage.getItem(BUNGIE_STATE_STORAGE);
+    const verifier = sessionStorage.getItem(BUNGIE_VERIFIER_STORAGE);
+    if(!storedState || !verifier || storedState !== state){
+      cleanOAuthParams();
+      setBungieStatus('Authorization state mismatch. Please try signing in again.', 'error');
+      sessionStorage.removeItem(BUNGIE_VERIFIER_STORAGE);
+      sessionStorage.removeItem(BUNGIE_STATE_STORAGE);
+      sessionStorage.removeItem(BUNGIE_RETURN_STORAGE);
+      return;
+    }
+    try{
+      setBungieStatus('Completing Bungie authorization…', 'loading');
+      const redirectUri = sessionStorage.getItem(BUNGIE_RETURN_STORAGE) || BUNGIE_REDIRECT_URI;
+      const loaded = await exchangeAuthCode(code, verifier, redirectUri);
+      if(!loaded){
+        const hasError = bungieStatusEl?.classList?.contains('status-error');
+        if(!hasError){
+          setBungieStatus('Authorization complete. Use Refresh armor to pull your gear.', 'ok');
+        }
+      }
+    }catch(err){
+      console.error(err);
+      setBungieStatus('Failed to complete authorization: ' + (err?.message || err), 'error');
+    }finally{
+      cleanOAuthParams();
+      sessionStorage.removeItem(BUNGIE_VERIFIER_STORAGE);
+      sessionStorage.removeItem(BUNGIE_STATE_STORAGE);
+      sessionStorage.removeItem(BUNGIE_RETURN_STORAGE);
+    }
+  }
+
+  async function exchangeAuthCode(code, verifier, redirectUri){
+    ensureBungieConfigDefaults();
+    const body = new URLSearchParams();
+    body.set('client_id', bungieConfig?.clientId || '');
+    body.set('grant_type', 'authorization_code');
+    body.set('code', code);
+    body.set('code_verifier', verifier);
+    if(redirectUri){
+      body.set('redirect_uri', redirectUri);
+    }
+    const headers = new Headers({
+      'Content-Type':'application/x-www-form-urlencoded',
+      'Accept':'application/json'
+    });
+    if(bungieConfig?.apiKey){
+      headers.set('X-API-Key', bungieConfig.apiKey);
+    }
+    const resp = await fetch(BUNGIE_TOKEN_URL, {
+      method:'POST',
+      headers,
+      body
+    });
+    const data = await resp.json().catch(()=>null);
+    if(!resp.ok){
+      const msg = data?.error_description || data?.Message || `HTTP ${resp.status}`;
+      throw new Error(msg);
+    }
+    if(!data?.access_token){
+      throw new Error('Missing access token in Bungie response.');
+    }
+    bungieTokens = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      accessTokenExpires: Date.now() + (Number(data.expires_in || 0) * 1000),
+      refreshTokenExpires: Date.now() + (Number(data.refresh_expires_in || 0) * 1000),
+      tokenType: data.token_type || 'Bearer',
+      membershipId: data.membership_id || bungieConfig?.membershipId || null,
+      membershipType: data.membership_type != null ? data.membership_type : bungieConfig?.membershipType || null
+    };
+    saveBungieTokens();
+    updateBungieUI();
+    const membership = await fetchMemberships();
+    if(membership){
+      const loaded = await loadArmorFromBungie({ reason: 'auto' });
+      return loaded;
+    }
+    return false;
+  }
+
+  async function ensureAccessToken(){
+    if(!bungieTokens?.refreshToken){
+      throw new Error('No Bungie session available. Sign in first.');
+    }
+    const now = Date.now();
+    if(bungieTokens.accessToken && now < ((bungieTokens.accessTokenExpires || 0) - 60000)){
+      return bungieTokens.accessToken;
+    }
+    if(now >= ((bungieTokens.refreshTokenExpires || 0) - 60000)){
+      throw new Error('Bungie session expired. Please sign in again.');
+    }
+    await refreshAccessToken();
+    return bungieTokens.accessToken;
+  }
+
+  async function refreshAccessToken(){
+    ensureBungieConfigDefaults();
+    const body = new URLSearchParams();
+    body.set('client_id', bungieConfig?.clientId || '');
+    body.set('grant_type', 'refresh_token');
+    body.set('refresh_token', bungieTokens?.refreshToken || '');
+    const headers = new Headers({
+      'Content-Type':'application/x-www-form-urlencoded',
+      'Accept':'application/json'
+    });
+    if(bungieConfig?.apiKey){
+      headers.set('X-API-Key', bungieConfig.apiKey);
+    }
+    const resp = await fetch(BUNGIE_TOKEN_URL, {
+      method:'POST',
+      headers,
+      body
+    });
+    const data = await resp.json().catch(()=>null);
+    if(!resp.ok || !data?.access_token){
+      const msg = data?.error_description || data?.Message || `HTTP ${resp.status}`;
+      clearBungieTokens(false);
+      throw new Error(msg);
+    }
+    bungieTokens.accessToken = data.access_token;
+    bungieTokens.accessTokenExpires = Date.now() + (Number(data.expires_in || 0) * 1000);
+    if(data.refresh_token){
+      bungieTokens.refreshToken = data.refresh_token;
+    }
+    if(data.refresh_expires_in){
+      bungieTokens.refreshTokenExpires = Date.now() + Number(data.refresh_expires_in) * 1000;
+    }
+    if(data.token_type){
+      bungieTokens.tokenType = data.token_type;
+    }
+    if(data.membership_id){
+      bungieTokens.membershipId = data.membership_id;
+    }
+    if(data.membership_type != null){
+      bungieTokens.membershipType = data.membership_type;
+    }
+    saveBungieTokens();
+  }
+
+  async function bungieApiRequest(path, options={}, retry=true){
+    ensureBungieConfigDefaults();
+    const cfg = bungieConfig || {};
+    if(!cfg.apiKey){
+      throw new Error('Bungie API key is missing.');
+    }
+    await ensureAccessToken();
+    const headers = new Headers(options.headers || {});
+    headers.set('X-API-Key', cfg.apiKey);
+    headers.set('Authorization', `${bungieTokens?.tokenType || 'Bearer'} ${bungieTokens?.accessToken || ''}`);
+    headers.set('Accept', 'application/json');
+    const resp = await fetch(`${BUNGIE_API_ROOT}${path}`, {
+      method: options.method || 'GET',
+      ...options,
+      headers
+    });
+    if(resp.status === 401 && retry){
+      await refreshAccessToken();
+      return bungieApiRequest(path, options, false);
+    }
+    const data = await resp.json().catch(()=>null);
+    if(!resp.ok){
+      const msg = data?.Message || data?.message || `HTTP ${resp.status}`;
+      throw new Error(msg);
+    }
+    if(data?.ErrorCode && data.ErrorCode !== 1){
+      throw new Error(data.Message || `Bungie API error ${data.ErrorCode}`);
+    }
+    return data?.Response;
+  }
+
+  function hashKey(hash){
+    const num = Number(hash);
+    if(Number.isNaN(num)) return String(hash);
+    return String(num >>> 0);
+  }
+
+  async function getInventoryItemDefinition(hash){
+    const key = hashKey(hash);
+    if(manifestCache.inventoryItem.has(key)){
+      return manifestCache.inventoryItem.get(key);
+    }
+    const def = await bungieApiRequest(`/Destiny2/Manifest/DestinyInventoryItemDefinition/${key}/`);
+    manifestCache.inventoryItem.set(key, def);
+    return def;
+  }
+
+  async function transformProfileToRows(profile){
+    const itemsMap = new Map();
+    const addItems = (items)=>{
+      if(!Array.isArray(items)) return;
+      for(const item of items){
+        if(!item || !item.itemInstanceId) continue;
+        if(itemsMap.has(item.itemInstanceId)) continue;
+        itemsMap.set(item.itemInstanceId, item);
+      }
+    };
+    addItems(profile?.profileInventory?.data?.items);
+    const charInventories = profile?.characterInventories?.data || {};
+    for(const inv of Object.values(charInventories)){
+      addItems(inv?.items);
+    }
+    const charEquipment = profile?.characterEquipment?.data || {};
+    for(const equip of Object.values(charEquipment)){
+      addItems(equip?.items);
+    }
+    if(itemsMap.size === 0) return [];
+    const instances = profile?.itemComponents?.instances?.data || {};
+    const statsByItem = profile?.itemComponents?.stats?.data || {};
+    const uniqueHashes = Array.from(new Set(Array.from(itemsMap.values()).map(it => hashKey(it.itemHash))));
+    await Promise.all(uniqueHashes.map(h => getInventoryItemDefinition(h)));
+    const rows = [];
+    for(const item of itemsMap.values()){
+      const def = await getInventoryItemDefinition(item.itemHash);
+      const row = buildRowFromDefinition(item, def, instances[item.itemInstanceId], statsByItem[item.itemInstanceId]?.stats || {});
+      if(row) rows.push(row);
+    }
+    return rows;
+  }
+
+  function buildRowFromDefinition(item, def, instance, stats){
+    if(!def || !def.inventory) return null;
+    if(def.itemType !== 2) return null;
+    if(def.classType != null && def.classType > 2 && def.classType !== 3 && def.classType !== 4) return null;
+    const bucketKey = hashKey(def.inventory.bucketTypeHash);
+    if(!ARMOR_BUCKET_HASH_TO_TYPE[bucketKey]) return null;
+    const className = CLASS_BY_TYPE[def.classType] || 'Any';
+    const isClassItem = bucketKey === String(1585787867);
+    const typeName = isClassItem
+      ? (classItemByClass[className] || def.itemTypeDisplayName || 'Class Item')
+      : (def.itemTypeDisplayName || ARMOR_BUCKET_HASH_TO_TYPE[bucketKey] || 'Armor');
+    const tierValue = instance?.energy?.energyCapacity ?? instance?.energy?.energyLevel ?? 0;
+    const row = {
+      Id: normId(item.itemInstanceId || item.itemHash),
+      Name: def?.displayProperties?.name || 'Unknown Item',
+      Type: typeName,
+      Equippable: className === 'Unknown' ? 'Any' : className,
+      Rarity: def?.inventory?.tierTypeName || '',
+      Tag: '',
+      Power: instance?.primaryStat?.value ?? '',
+      Tier: Number.isFinite(tierValue) ? tierValue : 0,
+      'Total (Base)': 0
+    };
+    for(const [hash,label] of Object.entries(STAT_HASH_TO_LABEL)){
+      const stat = stats?.[hash];
+      const value = Number(stat?.value ?? 0);
+      row[label] = Number.isFinite(value) ? value : 0;
+      row['Total (Base)'] += row[label];
+    }
+    row['Total (Base)'] = Number.isFinite(row['Total (Base)']) ? row['Total (Base)'] : 0;
+    return row;
+  }
+
+  async function fetchMemberships(){
+    try{
+      const resp = await bungieApiRequest('/User/GetMembershipsForCurrentUser/');
+      const memberships = Array.isArray(resp?.destinyMemberships) ? resp.destinyMemberships : [];
+      bungieMemberships = memberships.map(m => ({
+        membershipId: m.membershipId,
+        membershipType: m.membershipType,
+        label: formatMembershipLabel(m)
+      }));
+      let selected = null;
+      if(!bungieMemberships.length){
+        setBungieStatus('No Destiny 2 memberships were found for this account.', 'error');
+      }else{
+        selected = bungieMemberships.find(mem => String(mem.membershipType) === String(bungieConfig?.membershipType) && String(mem.membershipId) === String(bungieConfig?.membershipId)) || null;
+        if(!selected){
+          selected = bungieMemberships[0];
+          bungieConfig.membershipType = selected.membershipType;
+          bungieConfig.membershipId = selected.membershipId;
+          saveBungieConfig();
+        }
+        if(selected){
+          setBungieStatus(`Signed in as ${selected.label}.`, 'ok');
+        }else{
+          setBungieStatus('Signed in, but no profile is selected.', 'error');
+        }
+      }
+      renderMembershipOptions();
+      return selected;
+    }catch(err){
+      console.error(err);
+      setBungieStatus('Failed to load memberships: ' + (err?.message || err), 'error');
+    }
+  }
+
+  async function loadArmorFromBungie(options={}){
+    if(bungieIsFetching) return false;
+    const reason = options?.reason || 'manual';
+    let success = false;
+    try{
+      bungieIsFetching = true;
+      updateBungieUI();
+      const membership = getSelectedMembership();
+      if(!membership){
+        setBungieStatus('Select a Destiny profile before loading armor.', 'error');
+        return false;
+      }
+      const startMessage = reason === 'manual' ? 'Refreshing armor from Bungie…' : 'Loading armor from Bungie…';
+      setBungieStatus(startMessage, 'loading');
+      const profile = await bungieApiRequest(`/Destiny2/${membership.membershipType}/Profile/${membership.membershipId}/?components=${BUNGIE_COMPONENTS}`);
+      const rows = await transformProfileToRows(profile);
+      if(!rows.length){
+        setBungieStatus('No armor items were found for this profile.', 'error');
+        return false;
+      }
+      STATE.rows = rows;
+      saveRows();
+      render();
+      setUploadHint('Loaded via Bungie API');
+      const successMessage = reason === 'manual'
+        ? `Refreshed ${rows.length} armor items from Bungie.`
+        : `Loaded ${rows.length} armor items from Bungie.`;
+      setBungieStatus(successMessage, 'ok');
+      if(reason === 'auto'){
+        bungieAutoLoadedOnce = true;
+      }
+      success = true;
+    }catch(err){
+      console.error(err);
+      setBungieStatus('Failed to load armor: ' + (err?.message || err), 'error');
+    }finally{
+      bungieIsFetching = false;
+      updateBungieUI();
+    }
+    return success;
+  }
+
+  async function initBungieIntegration(){
+    updateBungieUI();
+    await handleOAuthRedirect();
+    if(bungieTokens?.refreshToken){
+      const refreshValid = Date.now() < ((bungieTokens.refreshTokenExpires || 0) - 60000);
+      if(!refreshValid){
+        clearBungieTokens(false);
+        setBungieStatus('Your Bungie session expired. Please sign in again.', 'error');
+        return;
+      }
+      try{
+        await ensureAccessToken();
+        let membership = getSelectedMembership();
+        if(!membership){
+          membership = await fetchMemberships();
+        }else{
+          renderMembershipOptions();
+        }
+        if(membership && !bungieAutoLoadedOnce){
+          const loaded = await loadArmorFromBungie({ reason: 'auto' });
+          if(!loaded && !bungieStatusEl?.textContent){
+            setBungieStatus(`Signed in as ${membership.label}. Use Refresh armor to try again.`, 'info');
+          }
+        }else if(membership && !bungieStatusEl?.textContent){
+          setBungieStatus(`Signed in as ${membership.label}.`, 'ok');
+        }
+      }catch(err){
+        console.error(err);
+        clearBungieTokens(false);
+        setBungieStatus('Your Bungie session expired. Please sign in again.', 'error');
+      }
+    }else if(!bungieStatusEl?.textContent){
+      setBungieStatus('Sign in with Bungie to sync your armor automatically.', 'info');
+    }
+  }
   // ====== Grouping & Sorting ======
   function clusterRows(filtered){
     const byKey = new Map();
@@ -505,6 +1226,35 @@ out.sort((a, b) => {
   }
 
   // ====== Events ======
+  bungieStatusEl = document.getElementById('bungieStatus');
+  bungieRedirectUriEl = document.getElementById('bungieRedirectUri');
+  bungieMembershipSelect = document.getElementById('membershipSelect');
+  bungieMembershipWrap = document.getElementById('membershipSelectWrap');
+  bungieLoginBtn = document.getElementById('bungieLogin');
+  bungieRefreshBtn = document.getElementById('bungieRefresh');
+  bungieLogoutBtn = document.getElementById('bungieLogout');
+
+  if(bungieRedirectUriEl){
+    bungieRedirectUriEl.textContent = BUNGIE_REDIRECT_URI;
+    bungieRedirectUriEl.title = BUNGIE_REDIRECT_URI;
+  }
+
+  if(bungieLoginBtn) bungieLoginBtn.addEventListener('click', () => startBungieAuth());
+  if(bungieRefreshBtn) bungieRefreshBtn.addEventListener('click', () => loadArmorFromBungie({ reason: 'manual' }));
+  if(bungieLogoutBtn) bungieLogoutBtn.addEventListener('click', () => { clearBungieTokens(true); });
+  if(bungieMembershipSelect){
+    bungieMembershipSelect.addEventListener('change', (event) => {
+      const value = event.target.value;
+      if(!value) return;
+      const [type, id] = value.split(':');
+      bungieConfig.membershipType = Number(type);
+      bungieConfig.membershipId = id;
+      saveBungieConfig();
+      updateBungieUI();
+      loadArmorFromBungie({ reason: 'auto' });
+    });
+  }
+
   const fileInput = document.getElementById('file');
   const restoreBtn = document.getElementById('restoreBtn');
   const clearBtn = document.getElementById('clearBtn');
@@ -599,6 +1349,7 @@ out.sort((a, b) => {
 }
 
   // Initial
+  initBungieIntegration().catch((err)=>{ console.error('Bungie init error', err); });
   const cached = loadRows(); if(cached){ STATE.rows=cached; }
   render();
   updateShadowColor();


### PR DESCRIPTION
## Summary
- streamline the Bungie panel into a one-click sign-in/refresh workflow that surfaces the ErebusAres client details and keeps tokens local to the browser
- harden the OAuth and API integration by enforcing default credentials, passing the API key during token exchanges, and automatically selecting memberships and loading armor after authentication or profile changes

## Testing
- Not run (OAuth flow requires Bungie services)

------
https://chatgpt.com/codex/tasks/task_e_68cb245d5404832d911c826a883aa6b5