### PR TITLE
Gate derived base stats and fix energy tier

### DIFF
--- a/beta.css
+++ b/beta.css
@@ -143,6 +143,270 @@ h1::after {
   flex: 1 1 auto;
 }
 
+.panel-auth {
+  margin-bottom: 16px;
+}
+
+.panel-auth h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.panel-debug {
+  margin-bottom: 16px;
+}
+
+.panel-debug h2 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.debug-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.debug-actions {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-small {
+  padding: 4px 10px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+}
+
+.debug-content {
+  margin-top: 14px;
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.debug-content.is-open {
+  display: flex;
+}
+
+.debug-section {
+  background: var(--panel2);
+  border: 1px solid var(--muted);
+  border-radius: 14px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.debug-section__title {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.debug-pre,
+.debug-log {
+  margin: 0;
+  background: rgba(4, 7, 15, 0.75);
+  border: 1px solid rgba(124, 215, 255, 0.12);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text);
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.debug-log {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.debug-entry {
+  border-left: 2px solid rgba(124, 215, 255, 0.3);
+  padding-left: 10px;
+}
+
+.debug-entry__time {
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  margin-bottom: 2px;
+}
+
+.debug-entry__message {
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+}
+
+.debug-entry__details {
+  margin-top: 4px;
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 10px;
+  line-height: 1.45;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.debug-empty {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.debug-notes {
+  min-height: 110px;
+  background: rgba(4, 7, 15, 0.55);
+  border: 1px solid var(--muted);
+  border-radius: 12px;
+  color: var(--text);
+  padding: 10px 12px;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  resize: vertical;
+}
+
+.debug-notes:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(124, 215, 255, 0.25);
+}
+
+.debug-note {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.auth-header {
+  margin-bottom: 12px;
+}
+
+.auth-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.auth-label {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+}
+
+.auth-field input,
+.auth-field select {
+  background: var(--panel2);
+  border: 1px solid var(--muted);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: var(--text);
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-field input:focus,
+.auth-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 215, 255, 0.15);
+}
+
+.auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.auth-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.auth-membership {
+  margin-bottom: 12px;
+}
+
+.auth-note {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.code-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: 'Fira Code', 'Source Code Pro', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: var(--panel2);
+  border: 1px solid var(--muted);
+  color: var(--text);
+  word-break: break-all;
+}
+
+.auth-status {
+  margin-top: 6px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  min-height: 18px;
+}
+
+.auth-status.status-ok {
+  color: var(--stat-green);
+}
+
+.auth-status.status-error {
+  color: #ff9ca1;
+}
+
+.auth-status.status-loading {
+  color: var(--accent);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  filter: grayscale(0.3);
+}
+
 .toolbar {
   display: flex;
   flex-direction: column;
@@ -356,6 +620,19 @@ button.tool-card {
   border-color: var(--accent);
   box-shadow: var(--glow);
   transform: translateY(-1px);
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, rgba(124, 215, 255, 0.4), rgba(159, 133, 255, 0.28));
+  color: var(--chip-active-text);
+  border-color: rgba(124, 215, 255, 0.8);
+  box-shadow: var(--glow);
+}
+
+.btn-primary:hover {
+  background: linear-gradient(120deg, rgba(124, 215, 255, 0.65), rgba(159, 133, 255, 0.45));
+  color: var(--chip-active-text);
+  border-color: var(--accent);
 }
 
 .filters {

--- a/beta.html
+++ b/beta.html
@@ -64,6 +64,56 @@
       </div>
     </header>
 
+    <section class="panel panel-auth" id="bungiePanel">
+      <div class="auth-header">
+        <h2>Connect with Bungie</h2>
+        <p class="muted">Sign in with your Bungie account to pull armor automatically, or continue using CSV uploads.</p>
+      </div>
+      <div class="auth-buttons">
+        <button id="bungieLogin" type="button" class="btn btn-primary">Sign in with Bungie</button>
+        <button id="bungieRefresh" type="button" class="btn">Refresh armor</button>
+        <button id="bungieLogout" type="button" class="btn">Sign out</button>
+      </div>
+      <div id="membershipSelectWrap" class="auth-membership" style="display:none">
+        <label class="auth-field">
+          <span class="auth-label">Active profile</span>
+          <select id="membershipSelect"></select>
+        </label>
+      </div>
+      <div class="auth-note muted">Tokens are stored locally in this browser only.</div>
+      <div id="bungieStatus" class="auth-status muted" aria-live="polite"></div>
+    </section>
+
+    <section class="panel panel-debug" id="debugPanel">
+      <div class="debug-header">
+        <h2>Debug Console</h2>
+        <div class="debug-actions">
+          <button id="debugToggle" type="button" class="btn btn-small">Show details</button>
+          <button id="debugCopy" type="button" class="btn btn-small">Copy snapshot</button>
+        </div>
+      </div>
+      <div id="debugContent" class="debug-content" hidden>
+        <div class="debug-section">
+          <div class="debug-section__title">Session snapshot</div>
+          <pre id="debugSnapshot" class="debug-pre">Collecting state…</pre>
+        </div>
+        <div class="debug-section">
+          <div class="debug-section__title">Recent events</div>
+          <div id="debugLog" class="debug-log" role="log" aria-live="polite"></div>
+        </div>
+        <div class="debug-section">
+          <div class="debug-section__title">Armor stat breakdown</div>
+          <div class="debug-note">First 8 armor rows captured per load. Share this with any bug reports.</div>
+          <pre id="debugArmorSamples" class="debug-pre">No armor samples yet — load armor from Bungie to capture data.</pre>
+        </div>
+        <div class="debug-section">
+          <label class="debug-section__title" for="debugNotes">Your observations (saved locally)</label>
+          <textarea id="debugNotes" class="debug-notes" placeholder="Add steps, timestamps, or anything else that might help troubleshoot issues."></textarea>
+          <div class="debug-note muted">Notes never leave this browser — copy them with the snapshot when you need to share details.</div>
+        </div>
+      </div>
+    </section>
+
     <section class="panel" style="margin-bottom:16px">
       <div class="filters">
         <div class="line"><span class="label">Class</span><div id="classSeg" class="seg"></div></div>
@@ -125,6 +175,7 @@
   const SLOT_OPTIONS = ["All", "Helmet", "Gauntlets", "Chest Armor", "Leg Armor", "Class Item"];
   const RARITY_OPTIONS = ["All", "Legendary", "Exotic"];  const DUPES_OPTIONS = ["All", "Only Dupes", "Only Same-Name"];
   const classItemByClass = { Warlock: "Warlock Bond", Hunter: "Hunter Cloak", Titan: "Titan Mark" };
+  const DESTINY_ITEM_STATE_MASTERWORK = 1 << 2; // DestinyItemState.Masterwork bit flag
   const TAG_EMOJIS = {
     favorite: "❤️",
     keep: "🏷️",
@@ -159,6 +210,99 @@
     "Bulwark": "https://www.bungie.net/common/destiny2_content/icons/cda905547dd9eac7a39e6e898f619bc5.png", // Health, Class
     "Gunner": "https://www.bungie.net/common/destiny2_content/icons/15e3b3c25a6d4606dcb887cb67c915a1.png" // Weapons, Grenade
   }
+  const CLASS_BY_TYPE = { 0: "Titan", 1: "Hunter", 2: "Warlock", 3: "Unknown", 4: "Any" };
+  const ARMOR_BUCKET_HASH_TO_TYPE = {
+    3448274439: "Helmet",
+    3551918588: "Gauntlets",
+    14239492: "Chest Armor",
+    20886954: "Leg Armor",
+    1585787867: "Class Item"
+  };
+  const STAT_HASH_TO_LABEL = {
+    392767087: "Health (Base)",
+    4244567218: "Melee (Base)",
+    1735777505: "Grenade (Base)",
+    144602215: "Super (Base)",
+    1943323491: "Class (Base)",
+    2996146975: "Weapons (Base)"
+  };
+  const ARMOR_INTRINSIC_PLUG_CATEGORY_HASHES = new Set([
+    1744546145  // PlugCategoryHashes.Intrinsics
+  ]);
+  const ARMOR_MOD_PLUG_CATEGORY_HASHES = new Set([
+    1202876185, // PlugCategoryHashes.EnhancementsActivity
+    640682011,  // PlugCategoryHashes.EnhancementsArms
+    383756333,  // PlugCategoryHashes.EnhancementsChest
+    1955304674, // PlugCategoryHashes.EnhancementsClass
+    744326128,  // PlugCategoryHashes.EnhancementsHead
+    1175552225, // PlugCategoryHashes.EnhancementsLegs
+    3773173029, // PlugCategoryHashes.EnhancementsArtifice
+    1934732343, // PlugCategoryHashes.EnhancementsArtificeExotic
+    3422420680, // PlugCategoryHashes.EnhancementsV2Arms
+    1526202480, // PlugCategoryHashes.EnhancementsV2Chest
+    912441879,  // PlugCategoryHashes.EnhancementsV2ClassItem
+    2487827355, // PlugCategoryHashes.EnhancementsV2General
+    2912171003, // PlugCategoryHashes.EnhancementsV2Head
+    2111701510, // PlugCategoryHashes.EnhancementsV2Legs
+    3347429529, // PlugCategoryHashes.EnhancementsUniversal
+    3481777685  // core.gear_systems.armor_tiering.plugs.tuning.mods (+Stat / -Stat mods)
+  ]);
+  const ARMOR_MOD_ITEM_CATEGORY_HASHES = new Set([
+    4104513227, // ItemCategoryHashes.ArmorMods
+    3723676689, // ItemCategoryHashes.ArmorModsChest
+    3196106184, // ItemCategoryHashes.ArmorModsClass
+    1037516129, // ItemCategoryHashes.ArmorModsClassHunter
+    1650311619, // ItemCategoryHashes.ArmorModsClassTitan
+    2955376534, // ItemCategoryHashes.ArmorModsClassWarlock
+    3872696960, // ItemCategoryHashes.ArmorModsGauntlets
+    1362265421, // ItemCategoryHashes.ArmorModsHelmet
+    3607371986, // ItemCategoryHashes.ArmorModsLegs
+    4062965806  // ItemCategoryHashes.ArmorModsGameplay
+  ]);
+  const ARMOR_BASE_SOCKET_CATEGORY_HASHES = new Set([
+    3154740035, // SocketCategoryHashes.ArmorPerks_LargePerk (intrinsic stat frames)
+    2518356196, // SocketCategoryHashes.ArmorPerks_Reusable
+    3956125808  // SocketCategoryHashes.IntrinsicTraits
+  ]);
+  const ARMOR_MOD_SOCKET_CATEGORY_HASHES = new Set([
+    590099826,  // SocketCategoryHashes.ArmorMods
+    760375309   // SocketCategoryHashes.ArmorTier (masterwork)
+  ]);
+  const MEMBERSHIP_TYPE_NAMES = {
+    1: "Xbox",
+    2: "PlayStation",
+    3: "Steam",
+    4: "Blizzard",
+    5: "Stadia",
+    6: "Epic",
+    7: "Demon",
+    10: "Tiger",
+    254: "BungieNet"
+  };
+  const BUNGIE_CONFIG_STORAGE = 'd2aa_bungie_cfg_v1';
+  const BUNGIE_TOKEN_STORAGE = 'd2aa_bungie_tokens_v1';
+  const BUNGIE_STATE_STORAGE = 'd2aa_bungie_state_v1';
+  const BUNGIE_VERIFIER_STORAGE = 'd2aa_bungie_verifier_v1';
+  const BUNGIE_RETURN_STORAGE = 'd2aa_bungie_return_v1';
+  const BUNGIE_COMPONENTS = '100,102,200,201,205,300,304,305';
+  const BUNGIE_OAUTH_URL = 'https://www.bungie.net/en/OAuth/Authorize';
+  const BUNGIE_TOKEN_URL = 'https://www.bungie.net/Platform/App/OAuth/Token/';
+  const BUNGIE_API_ROOT = 'https://www.bungie.net/Platform';
+  const BUNGIE_REDIRECT_URI = (() => {
+    try {
+      const { origin, pathname } = window.location;
+      if (!origin || origin === 'null') {
+        return 'https://erebusares.github.io/D2AA/beta.html';
+      }
+      return `${origin}${pathname}`;
+    } catch (err) {
+      console.warn('Falling back to default Bungie redirect URI', err);
+      return 'https://erebusares.github.io/D2AA/beta.html';
+    }
+  })();
+  const BUNGIE_DEFAULT_API_KEY = '96e154014bdd44c0a537e482709b7473';
+  const BUNGIE_DEFAULT_CLIENT_ID = '50794';
+  const BUNGIE_ALLOWED_ORIGIN = 'https://erebusares.github.io';
   // ====== Helpers ======
   const normId = (s) => (s ? String(s).trim().replace(/^"|"$/g, "") : "");
   const normName = (s) => String(s || "").trim().toLowerCase();
@@ -197,16 +341,317 @@
     }
   }
 
+  // ====== Debug Panel ======
+  const DEBUG_LOG_LIMIT = 200;
+  const DEBUG_NOTES_STORAGE = 'd2aa_debug_notes_v1';
+  const ARMOR_DEBUG_SAMPLE_LIMIT = 8;
+  const debugState = {
+    entries: [],
+    snapshotText: '',
+    snapshotData: null,
+    isOpen: false,
+    lastStatus: { message: '', type: 'info' },
+    lastUiStateSignature: '',
+    copyResetTimer: null,
+    lastRenderCount: null,
+    armorSamples: []
+  };
+  const debugEls = {
+    panel: null,
+    toggle: null,
+    copy: null,
+    content: null,
+    log: null,
+    snapshot: null,
+    notes: null,
+    armor: null
+  };
+
+  function safeSerialize(value){
+    if(value == null) return '';
+    if(typeof value === 'string') return value;
+    try{
+      return JSON.stringify(value, null, 2);
+    }catch(err){
+      return String(value);
+    }
+  }
+
+  function escapeHtml(value){
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function maskSecret(value){
+    if(!value) return null;
+    const str = String(value);
+    if(str.length <= 4) return '••••';
+    const visible = str.slice(-4);
+    return `${'•'.repeat(Math.max(0, str.length - 4))}${visible}`;
+  }
+
+  function loadDebugNotes(){
+    try{
+      return localStorage.getItem(DEBUG_NOTES_STORAGE) || '';
+    }catch(err){
+      console.warn('Failed to load debug notes', err);
+      return '';
+    }
+  }
+
+  function saveDebugNotes(notes){
+    try{
+      if(notes && notes.trim()){
+        localStorage.setItem(DEBUG_NOTES_STORAGE, notes);
+      }else{
+        localStorage.removeItem(DEBUG_NOTES_STORAGE);
+      }
+    }catch(err){
+      console.warn('Failed to persist debug notes', err);
+    }
+  }
+
+  function renderDebugLog(){
+    if(!debugEls.log){
+      return;
+    }
+    if(!debugState.entries.length){
+      debugEls.log.innerHTML = '<div class="debug-empty">No debug events yet.</div>';
+      return;
+    }
+    const items = [...debugState.entries].reverse().map((entry) => {
+      const detailsHtml = entry.details ? `<div class="debug-entry__details">${escapeHtml(entry.details)}</div>` : '';
+      return `<div class="debug-entry"><div class="debug-entry__time">${escapeHtml(entry.timestamp)}</div><div class="debug-entry__message">${escapeHtml(entry.message)}</div>${detailsHtml}</div>`;
+    }).join('');
+    debugEls.log.innerHTML = items;
+  }
+
+  function renderDebugArmorSamples(){
+    if(!debugEls.armor){
+      return;
+    }
+    if(!debugState.armorSamples.length){
+      debugEls.armor.textContent = 'No armor samples yet — load armor from Bungie to capture data.';
+      return;
+    }
+    const sections = debugState.armorSamples.map((sample, index) => {
+      const header = `#${index + 1} ${sample.name} • ${sample.type} (Tier ${sample.tier ?? 0})`;
+      const payload = {
+        instanceId: sample.instanceId,
+        itemHash: sample.itemHash,
+        energy: sample.energy,
+        stats: sample.stats,
+        sockets: sample.sockets
+      };
+      return `${header}\n${safeSerialize(payload)}`;
+    }).join('\n\n');
+    debugEls.armor.textContent = sections;
+  }
+
+  function recordArmorDebugSample(sample){
+    if(!sample){
+      return;
+    }
+    debugState.armorSamples.push(sample);
+    if(debugState.armorSamples.length > ARMOR_DEBUG_SAMPLE_LIMIT){
+      debugState.armorSamples.splice(0, debugState.armorSamples.length - ARMOR_DEBUG_SAMPLE_LIMIT);
+    }
+    renderDebugArmorSamples();
+  }
+
+  function buildDebugSnapshotData(){
+    const now = Date.now();
+    const selected = bungieMemberships.find((mem) => String(mem.membershipType) === String(bungieConfig?.membershipType) && String(mem.membershipId) === String(bungieConfig?.membershipId)) || null;
+    const inventorySize = manifestCache?.inventoryItem instanceof Map ? manifestCache.inventoryItem.size : 0;
+    const bucketSize = manifestCache?.bucket instanceof Map ? manifestCache.bucket.size : 0;
+    const socketSize = manifestCache?.socketType instanceof Map ? manifestCache.socketType.size : 0;
+    return {
+      generatedAt: new Date(now).toISOString(),
+      status: debugState.lastStatus,
+      ui: {
+        bungieIsFetching,
+        bungieAutoLoadedOnce,
+        rowsLoaded: Array.isArray(STATE?.rows) ? STATE.rows.length : 0
+      },
+      config: {
+        clientId: bungieConfig?.clientId || null,
+        membershipId: bungieConfig?.membershipId || null,
+        membershipType: bungieConfig?.membershipType || null,
+        apiKeyMasked: maskSecret(bungieConfig?.apiKey)
+      },
+      tokens: {
+        hasAccessToken: Boolean(bungieTokens?.accessToken),
+        hasRefreshToken: Boolean(bungieTokens?.refreshToken),
+        accessTokenExpiresInMs: bungieTokens?.accessTokenExpires ? bungieTokens.accessTokenExpires - now : null,
+        refreshTokenExpiresInMs: bungieTokens?.refreshTokenExpires ? bungieTokens.refreshTokenExpires - now : null,
+        tokenType: bungieTokens?.tokenType || null
+      },
+      memberships: {
+        total: bungieMemberships.length,
+        selected: selected ? { membershipId: selected.membershipId, membershipType: selected.membershipType, label: selected.label } : null
+      },
+      manifestCache: {
+        inventoryItem: inventorySize,
+        bucket: bucketSize,
+        socketType: socketSize
+      },
+      armorSamplesCaptured: debugState.armorSamples.length
+    };
+  }
+
+  function updateDebugSnapshot(){
+    const snapshot = buildDebugSnapshotData();
+    debugState.snapshotData = snapshot;
+    debugState.snapshotText = safeSerialize(snapshot);
+    if(debugEls.snapshot){
+      debugEls.snapshot.textContent = debugState.snapshotText;
+    }
+  }
+
+  function logDebug(message, details){
+    const entry = {
+      timestamp: new Date().toISOString(),
+      message: String(message || 'log'),
+      details: safeSerialize(details)
+    };
+    debugState.entries.push(entry);
+    if(debugState.entries.length > DEBUG_LOG_LIMIT){
+      debugState.entries.splice(0, debugState.entries.length - DEBUG_LOG_LIMIT);
+    }
+    renderDebugLog();
+  }
+
+  function buildDebugDump(){
+    const lines = [];
+    lines.push('D2 Armor Analyzer Debug Snapshot');
+    lines.push(`Generated: ${new Date().toISOString()}`);
+    lines.push('');
+    lines.push('--- Snapshot ---');
+    lines.push(debugState.snapshotText || safeSerialize(buildDebugSnapshotData()));
+    lines.push('');
+    lines.push('--- Recent events ---');
+    if(debugState.entries.length){
+      for(const entry of debugState.entries){
+        lines.push(`${entry.timestamp} :: ${entry.message}`);
+        if(entry.details){
+          lines.push(entry.details);
+        }
+        lines.push('');
+      }
+    }else{
+      lines.push('(no events logged)');
+    }
+    lines.push('--- Notes ---');
+    const notesValue = debugEls.notes?.value ?? loadDebugNotes();
+    lines.push(notesValue ? notesValue : '(none)');
+    return lines.join('\n');
+  }
+
+  function setDebugContentOpen(force){
+    if(!debugEls.content){
+      return;
+    }
+    const next = force != null ? Boolean(force) : !debugState.isOpen;
+    debugState.isOpen = next;
+    if(next){
+      debugEls.content.hidden = false;
+      debugEls.content.classList.add('is-open');
+      if(debugEls.toggle){
+        debugEls.toggle.textContent = 'Hide details';
+      }
+    }else{
+      debugEls.content.hidden = true;
+      debugEls.content.classList.remove('is-open');
+      if(debugEls.toggle){
+        debugEls.toggle.textContent = 'Show details';
+      }
+    }
+  }
+
+  function initDebugPanel(){
+    debugEls.panel = document.getElementById('debugPanel');
+    if(!debugEls.panel){
+      return;
+    }
+    debugEls.toggle = document.getElementById('debugToggle');
+    debugEls.copy = document.getElementById('debugCopy');
+    debugEls.content = document.getElementById('debugContent');
+    debugEls.log = document.getElementById('debugLog');
+    debugEls.snapshot = document.getElementById('debugSnapshot');
+    debugEls.notes = document.getElementById('debugNotes');
+    debugEls.armor = document.getElementById('debugArmorSamples');
+    if(debugEls.toggle){
+      debugEls.toggle.addEventListener('click', () => {
+        setDebugContentOpen();
+        updateDebugSnapshot();
+      });
+    }
+    if(debugEls.copy){
+      debugEls.copy.addEventListener('click', async () => {
+        const dump = buildDebugDump();
+        const ok = await copyTextSafe(dump);
+        if(debugState.copyResetTimer){
+          clearTimeout(debugState.copyResetTimer);
+          debugState.copyResetTimer = null;
+        }
+        if(ok){
+          debugEls.copy.textContent = 'Copied!';
+        }else{
+          debugEls.copy.textContent = 'Copy failed';
+        }
+        debugState.copyResetTimer = setTimeout(() => {
+          debugEls.copy.textContent = 'Copy snapshot';
+        }, 2000);
+      });
+    }
+    if(debugEls.notes){
+      debugEls.notes.value = loadDebugNotes();
+      debugEls.notes.addEventListener('input', (event) => {
+        saveDebugNotes(event.target.value);
+      });
+    }
+    renderDebugLog();
+    renderDebugArmorSamples();
+    updateDebugSnapshot();
+    setDebugContentOpen(false);
+    logDebug('Debug panel initialized');
+  }
+
   // ====== State & Storage ======
-  let STATE = { 
-    rows:[], 
-    classFilter:'Warlock', 
-    slotFilter:'All', 
-    rarityFilter:'All', 
-    tol:5, 
+  let STATE = {
+    rows:[],
+    classFilter:'Warlock',
+    slotFilter:'All',
+    rarityFilter:'All',
+    tol:5,
     dupesFilter:'All' // NEW
   };
   const LS_KEY = 'd2_armor_rows_v1';
+  let bungieConfig = loadBungieConfig();
+  let bungieTokens = loadBungieTokens();
+  let bungieMemberships = [];
+  let bungieIsFetching = false;
+  let bungieAutoLoadedOnce = false;
+  const manifestCache = {
+    inventoryItem: new Map(),
+    bucket: new Map(),
+    socketType: new Map()
+  };
+  const MANIFEST_COMPONENT_INVENTORY_ITEM = 'DestinyInventoryItemDefinition';
+  const MANIFEST_COMPONENT_SOCKET_TYPE = 'DestinySocketTypeDefinition';
+  let manifestIndexPromise = null;
+  const manifestComponentCache = new Map();
+  const manifestComponentPromises = new Map();
+  let bungieStatusEl = null;
+  let bungieMembershipSelect = null;
+  let bungieMembershipWrap = null;
+  let bungieLoginBtn = null;
+  let bungieRefreshBtn = null;
+  let bungieLogoutBtn = null;
   function saveRows(){ try{ localStorage.setItem(LS_KEY, JSON.stringify(STATE.rows)); }catch(_){} }
   function loadRows(){ try{ const s=localStorage.getItem(LS_KEY); if(!s) return null; return JSON.parse(s); }catch(_){ return null; } }
 
@@ -279,6 +724,1519 @@
   return grouped;
 }
 
+  // ====== Bungie API Integration ======
+  function getDefaultTokenState(){
+    return {
+      accessToken:null,
+      refreshToken:null,
+      accessTokenExpires:0,
+      refreshTokenExpires:0,
+      tokenType:'Bearer',
+      membershipId:null,
+      membershipType:null
+    };
+  }
+
+  function loadBungieConfig(){
+    const defaults = {
+      apiKey: BUNGIE_DEFAULT_API_KEY,
+      clientId: BUNGIE_DEFAULT_CLIENT_ID,
+      membershipId: null,
+      membershipType: null
+    };
+    try{
+      const raw = localStorage.getItem(BUNGIE_CONFIG_STORAGE);
+      if(!raw) return { ...defaults };
+      const parsed = JSON.parse(raw);
+      return {
+        apiKey: BUNGIE_DEFAULT_API_KEY,
+        clientId: BUNGIE_DEFAULT_CLIENT_ID,
+        membershipId: parsed?.membershipId ?? null,
+        membershipType: parsed?.membershipType ?? null
+      };
+    }catch(err){
+      console.warn('Failed to parse Bungie config', err);
+      return { ...defaults };
+    }
+  }
+
+  function saveBungieConfig(){
+    try{
+      const payload = {
+        membershipId: bungieConfig?.membershipId ?? null,
+        membershipType: bungieConfig?.membershipType ?? null
+      };
+      localStorage.setItem(BUNGIE_CONFIG_STORAGE, JSON.stringify(payload));
+    }catch(err){
+      console.warn('Failed to persist Bungie config', err);
+    }
+    logDebug('saveBungieConfig', {
+      membershipId: bungieConfig?.membershipId ?? null,
+      membershipType: bungieConfig?.membershipType ?? null
+    });
+    updateDebugSnapshot();
+  }
+
+  function ensureBungieConfigDefaults(){
+    if(!bungieConfig) bungieConfig = loadBungieConfig();
+    bungieConfig.apiKey = BUNGIE_DEFAULT_API_KEY;
+    bungieConfig.clientId = BUNGIE_DEFAULT_CLIENT_ID;
+    if(bungieConfig.membershipId == null) bungieConfig.membershipId = null;
+    if(bungieConfig.membershipType == null) bungieConfig.membershipType = null;
+  }
+
+  function loadBungieTokens(){
+    const defaults = getDefaultTokenState();
+    try{
+      const raw = localStorage.getItem(BUNGIE_TOKEN_STORAGE);
+      if(!raw) return { ...defaults };
+      const parsed = JSON.parse(raw);
+      return { ...defaults, ...parsed };
+    }catch(err){
+      console.warn('Failed to load Bungie tokens', err);
+      return { ...defaults };
+    }
+  }
+
+  function saveBungieTokens(){
+    const hasAccessToken = Boolean(bungieTokens?.accessToken);
+    const hasRefreshToken = Boolean(bungieTokens?.refreshToken);
+    try{
+      if(!hasAccessToken && !hasRefreshToken){
+        localStorage.removeItem(BUNGIE_TOKEN_STORAGE);
+      }else{
+        localStorage.setItem(BUNGIE_TOKEN_STORAGE, JSON.stringify(bungieTokens));
+      }
+    }catch(err){
+      console.warn('Failed to persist Bungie tokens', err);
+    }
+    logDebug('saveBungieTokens', {
+      hasAccessToken,
+      hasRefreshToken
+    });
+    updateDebugSnapshot();
+  }
+
+  function clearBungieTokens(showMessage){
+    bungieTokens = getDefaultTokenState();
+    bungieMemberships = [];
+    bungieAutoLoadedOnce = false;
+    localStorage.removeItem(BUNGIE_TOKEN_STORAGE);
+    renderMembershipOptions();
+    updateBungieUI();
+    if(showMessage){
+      setBungieStatus('Signed out. You can still upload CSV files manually.', 'info');
+    }
+    logDebug('clearBungieTokens', { showMessage: Boolean(showMessage) });
+    updateDebugSnapshot();
+  }
+
+  function updateBungieUI(){
+    const hasConfig = Boolean((bungieConfig?.apiKey || '').trim() && (bungieConfig?.clientId || '').trim());
+    const hasRefresh = Boolean(bungieTokens?.refreshToken);
+    const refreshValid = hasRefresh && Date.now() < ((bungieTokens.refreshTokenExpires || 0) - 60000);
+    const signedIn = hasRefresh && refreshValid;
+    if(bungieLoginBtn) bungieLoginBtn.disabled = bungieIsFetching || !hasConfig;
+    if(bungieRefreshBtn) bungieRefreshBtn.disabled = bungieIsFetching || !signedIn || !hasConfig;
+    if(bungieLogoutBtn) bungieLogoutBtn.disabled = bungieIsFetching || !hasRefresh;
+    if(bungieMembershipWrap){
+      bungieMembershipWrap.style.display = bungieMemberships.length ? 'block' : 'none';
+    }
+    const uiSignature = JSON.stringify({ hasConfig, hasRefresh, refreshValid, signedIn, bungieIsFetching });
+    if(uiSignature !== debugState.lastUiStateSignature){
+      debugState.lastUiStateSignature = uiSignature;
+      logDebug('updateBungieUI', { hasConfig, hasRefresh, refreshValid, signedIn, bungieIsFetching });
+    }
+    updateDebugSnapshot();
+  }
+
+  function renderMembershipOptions(){
+    if(!bungieMembershipSelect || !bungieMembershipWrap){
+      return;
+    }
+    bungieMembershipSelect.innerHTML = '';
+    if(!bungieMemberships.length){
+      bungieMembershipWrap.style.display = 'none';
+      return;
+    }
+    bungieMembershipWrap.style.display = 'block';
+    let hasSelection = false;
+    for(const mem of bungieMemberships){
+      const opt = document.createElement('option');
+      opt.value = `${mem.membershipType}:${mem.membershipId}`;
+      opt.textContent = mem.label;
+      if(String(bungieConfig?.membershipType) === String(mem.membershipType) && String(bungieConfig?.membershipId) === String(mem.membershipId)){
+        opt.selected = true;
+        hasSelection = true;
+      }
+      bungieMembershipSelect.appendChild(opt);
+    }
+    if(!hasSelection && bungieMembershipSelect.options.length > 0){
+      bungieMembershipSelect.selectedIndex = 0;
+      const [type,id] = bungieMembershipSelect.value.split(':');
+      bungieConfig.membershipType = Number(type);
+      bungieConfig.membershipId = id;
+      saveBungieConfig();
+    }
+    logDebug('renderMembershipOptions', {
+      totalMemberships: bungieMemberships.length,
+      selectedMembership: bungieMembershipSelect?.value || null
+    });
+    updateBungieUI();
+  }
+
+  function formatMembershipLabel(mem){
+    const code = mem?.bungieGlobalDisplayNameCode != null ? String(mem.bungieGlobalDisplayNameCode).padStart(4,'0') : '';
+    const baseName = mem?.bungieGlobalDisplayName ? `${mem.bungieGlobalDisplayName}${code ? '#' + code : ''}` : (mem?.displayName || mem?.lastSeenDisplayName || 'Guardian');
+    const platform = MEMBERSHIP_TYPE_NAMES[mem?.membershipType] || `Type ${mem?.membershipType}`;
+    return `${baseName} • ${platform}`;
+  }
+
+  function getSelectedMembership(){
+    if(!bungieMemberships.length) return null;
+    const found = bungieMemberships.find(mem => String(mem.membershipType) === String(bungieConfig?.membershipType) && String(mem.membershipId) === String(bungieConfig?.membershipId));
+    if(found) return found;
+    const fallback = bungieMemberships[0];
+    if(fallback){
+      bungieConfig.membershipType = fallback.membershipType;
+      bungieConfig.membershipId = fallback.membershipId;
+      saveBungieConfig();
+      renderMembershipOptions();
+    }
+    return fallback || null;
+  }
+
+  function setBungieStatus(message, type='info'){
+    const normalizedMessage = message || '';
+    const changed = debugState.lastStatus.message !== normalizedMessage || debugState.lastStatus.type !== type;
+    debugState.lastStatus = { message: normalizedMessage, type };
+    if(changed){
+      logDebug('status', { message: normalizedMessage, type });
+    }
+    updateDebugSnapshot();
+    if(!bungieStatusEl) return;
+    bungieStatusEl.textContent = normalizedMessage;
+    bungieStatusEl.classList.remove('status-ok','status-error','status-loading');
+    const isInfo = !normalizedMessage || type === 'info';
+    bungieStatusEl.classList.toggle('muted', isInfo);
+    if(type === 'ok') bungieStatusEl.classList.add('status-ok');
+    else if(type === 'error') bungieStatusEl.classList.add('status-error');
+    else if(type === 'loading') bungieStatusEl.classList.add('status-loading');
+  }
+
+  const PKCE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+
+  function randomString(length){
+    const array = new Uint8Array(length);
+    if(window.crypto?.getRandomValues){
+      window.crypto.getRandomValues(array);
+    }else{
+      for(let i=0;i<length;i++){ array[i] = Math.floor(Math.random()*PKCE_CHARSET.length); }
+    }
+    let out = '';
+    for(let i=0;i<length;i++){
+      out += PKCE_CHARSET[array[i] % PKCE_CHARSET.length];
+    }
+    return out;
+  }
+
+  function base64UrlEncode(buffer){
+    let binary = '';
+    const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+    for(let i=0;i<bytes.byteLength;i++){
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  }
+
+  async function createCodeChallenge(verifier){
+    if(!window.crypto?.subtle){
+      throw new Error('Browser crypto API is not available for PKCE.');
+    }
+    const data = new TextEncoder().encode(verifier);
+    const digest = await window.crypto.subtle.digest('SHA-256', data);
+    return base64UrlEncode(new Uint8Array(digest));
+  }
+
+  async function startBungieAuth(){
+    try{
+      ensureBungieConfigDefaults();
+      logDebug('startBungieAuth', {
+        hasClientId: Boolean(bungieConfig?.clientId),
+        hasApiKey: Boolean(bungieConfig?.apiKey)
+      });
+      if(!bungieConfig?.clientId || !bungieConfig?.apiKey){
+        setBungieStatus('Bungie credentials are missing. Refresh and try again.', 'error');
+        return;
+      }
+      saveBungieConfig();
+      const verifier = randomString(64);
+      const challenge = await createCodeChallenge(verifier);
+      const state = randomString(32);
+      const returnUrl = window.location.href.split('#')[0];
+      const redirectUri = BUNGIE_REDIRECT_URI || returnUrl;
+      sessionStorage.setItem(BUNGIE_VERIFIER_STORAGE, verifier);
+      sessionStorage.setItem(BUNGIE_STATE_STORAGE, state);
+      sessionStorage.setItem(BUNGIE_RETURN_STORAGE, returnUrl);
+      const url = new URL(BUNGIE_OAUTH_URL);
+      url.searchParams.set('client_id', bungieConfig.clientId);
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('state', state);
+      url.searchParams.set('code_challenge', challenge);
+      url.searchParams.set('code_challenge_method', 'S256');
+      if(redirectUri){
+        url.searchParams.set('redirect_uri', redirectUri);
+      }
+      setBungieStatus('Redirecting to Bungie for sign-in…', 'loading');
+      logDebug('bungieAuthRedirect', {
+        redirectUri,
+        returnUrl,
+        state,
+        hasVerifier: Boolean(verifier)
+      });
+      window.location.href = url.toString();
+    }catch(err){
+      console.error(err);
+      logDebug('startBungieAuth error', { error: err?.message || err });
+      setBungieStatus('Unable to start Bungie sign-in: ' + (err?.message || err), 'error');
+    }
+  }
+
+  function cleanOAuthParams(){
+    const storedReturn = sessionStorage.getItem(BUNGIE_RETURN_STORAGE);
+    if(storedReturn){
+      window.history.replaceState({}, document.title, storedReturn);
+      return;
+    }
+    try{
+      const current = new URL(window.location.href);
+      current.searchParams.delete('code');
+      current.searchParams.delete('state');
+      current.searchParams.delete('error');
+      current.searchParams.delete('error_description');
+      window.history.replaceState({}, document.title, current.toString());
+    }catch(err){
+      console.warn('Failed to clean OAuth params', err);
+    }
+  }
+
+  async function handleOAuthRedirect(){
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get('error');
+    logDebug('handleOAuthRedirect', {
+      hasCode: params.has('code'),
+      hasError: Boolean(error)
+    });
+    if(error){
+      cleanOAuthParams();
+      setBungieStatus(`Authorization failed: ${error}`, 'error');
+      sessionStorage.removeItem(BUNGIE_VERIFIER_STORAGE);
+      sessionStorage.removeItem(BUNGIE_STATE_STORAGE);
+      sessionStorage.removeItem(BUNGIE_RETURN_STORAGE);
+      logDebug('handleOAuthRedirect error', { error });
+      return;
+    }
+    const code = params.get('code');
+    if(!code) return;
+    const state = params.get('state');
+    const storedState = sessionStorage.getItem(BUNGIE_STATE_STORAGE);
+    const verifier = sessionStorage.getItem(BUNGIE_VERIFIER_STORAGE);
+    if(!storedState || !verifier || storedState !== state){
+      cleanOAuthParams();
+      setBungieStatus('Authorization state mismatch. Please try signing in again.', 'error');
+      sessionStorage.removeItem(BUNGIE_VERIFIER_STORAGE);
+      sessionStorage.removeItem(BUNGIE_STATE_STORAGE);
+      sessionStorage.removeItem(BUNGIE_RETURN_STORAGE);
+      logDebug('handleOAuthRedirect stateMismatch', { storedState, state, hasVerifier: Boolean(verifier) });
+      return;
+    }
+    try{
+      setBungieStatus('Completing Bungie authorization…', 'loading');
+      logDebug('exchangeAuthCode start', { hasCode: Boolean(code), hasVerifier: Boolean(verifier) });
+      const redirectUri = sessionStorage.getItem(BUNGIE_RETURN_STORAGE) || BUNGIE_REDIRECT_URI;
+      const loaded = await exchangeAuthCode(code, verifier, redirectUri);
+      if(!loaded){
+        const hasError = bungieStatusEl?.classList?.contains('status-error');
+        if(!hasError){
+          setBungieStatus('Authorization complete. Use Refresh armor to pull your gear.', 'ok');
+        }
+        logDebug('exchangeAuthCode completed', { autoLoaded: Boolean(loaded) });
+      }
+    }catch(err){
+      console.error(err);
+      logDebug('handleOAuthRedirect exception', { error: err?.message || err });
+      setBungieStatus('Failed to complete authorization: ' + (err?.message || err), 'error');
+    }finally{
+      cleanOAuthParams();
+      sessionStorage.removeItem(BUNGIE_VERIFIER_STORAGE);
+      sessionStorage.removeItem(BUNGIE_STATE_STORAGE);
+      sessionStorage.removeItem(BUNGIE_RETURN_STORAGE);
+    }
+  }
+
+  async function exchangeAuthCode(code, verifier, redirectUri){
+    ensureBungieConfigDefaults();
+    const body = new URLSearchParams();
+    body.set('client_id', bungieConfig?.clientId || '');
+    body.set('grant_type', 'authorization_code');
+    body.set('code', code);
+    body.set('code_verifier', verifier);
+    if(redirectUri){
+      body.set('redirect_uri', redirectUri);
+    }
+    const headers = new Headers({
+      'Content-Type':'application/x-www-form-urlencoded',
+      'Accept':'application/json'
+    });
+    logDebug('exchangeAuthCode fetch', {
+      hasCode: Boolean(code),
+      hasVerifier: Boolean(verifier),
+      redirectUri
+    });
+    let resp;
+    try{
+      resp = await fetch(BUNGIE_TOKEN_URL, {
+        method:'POST',
+        headers,
+        body
+      });
+    }catch(err){
+      logDebug('exchangeAuthCode networkError', { error: err?.message || err });
+      throw new Error(formatBungieNetworkError(err));
+    }
+    const data = await resp.json().catch(()=>null);
+    if(!resp.ok){
+      const rawMsg = data?.error_description || data?.Message || `HTTP ${resp.status}`;
+      const msg = rawMsg === 'OriginHeaderDoesNotMatchKey'
+        ? 'OriginHeaderDoesNotMatchKey: Add https://erebusares.github.io to the Origin Header whitelist for your Bungie application and redeploy.'
+        : rawMsg;
+      logDebug('exchangeAuthCode failed', { status: resp.status, message: msg });
+      throw new Error(msg);
+    }
+    if(!data?.access_token){
+      logDebug('exchangeAuthCode missingAccessToken', { hasAccessToken: Boolean(data?.access_token) });
+      throw new Error('Missing access token in Bungie response.');
+    }
+    bungieTokens = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      accessTokenExpires: Date.now() + (Number(data.expires_in || 0) * 1000),
+      refreshTokenExpires: Date.now() + (Number(data.refresh_expires_in || 0) * 1000),
+      tokenType: data.token_type || 'Bearer',
+      membershipId: data.membership_id || bungieConfig?.membershipId || null,
+      membershipType: data.membership_type != null ? data.membership_type : bungieConfig?.membershipType || null
+    };
+    saveBungieTokens();
+    updateBungieUI();
+    logDebug('exchangeAuthCode success', {
+      membershipId: bungieTokens.membershipId,
+      membershipType: bungieTokens.membershipType,
+      accessExpiresIn: Number(data.expires_in || 0),
+      refreshExpiresIn: Number(data.refresh_expires_in || 0)
+    });
+    const membership = await fetchMemberships();
+    if(membership){
+      const loaded = await loadArmorFromBungie({ reason: 'auto' });
+      return loaded;
+    }
+    return false;
+  }
+
+  async function ensureAccessToken(){
+    const hasAccess = Boolean(bungieTokens?.accessToken);
+    const hasRefresh = Boolean(bungieTokens?.refreshToken);
+    const now = Date.now();
+    const accessExpires = Number(bungieTokens?.accessTokenExpires || 0);
+    const refreshExpires = Number(bungieTokens?.refreshTokenExpires || 0);
+
+    // If we have a usable access token, return it even if no refresh token exists yet.
+    if(hasAccess && (!accessExpires || now < (accessExpires - 60000))){
+      logDebug('ensureAccessToken cached', {
+        accessTokenExpiresInMs: accessExpires ? accessExpires - now : null
+      });
+      return bungieTokens.accessToken;
+    }
+
+    if(!hasRefresh){
+      logDebug('ensureAccessToken missingRefresh', {});
+      throw new Error('No Bungie session available. Sign in first.');
+    }
+
+    if(refreshExpires && now >= (refreshExpires - 60000)){
+      logDebug('ensureAccessToken refreshExpired', {
+        refreshExpiresInMs: refreshExpires - now
+      });
+      clearBungieTokens(false);
+      throw new Error('Bungie session expired. Please sign in again.');
+    }
+
+    logDebug('ensureAccessToken refreshing', {
+      refreshExpiresInMs: refreshExpires ? refreshExpires - now : null
+    });
+    await refreshAccessToken();
+    return bungieTokens.accessToken;
+  }
+
+  async function refreshAccessToken(){
+    ensureBungieConfigDefaults();
+    const body = new URLSearchParams();
+    body.set('client_id', bungieConfig?.clientId || '');
+    body.set('grant_type', 'refresh_token');
+    body.set('refresh_token', bungieTokens?.refreshToken || '');
+    const headers = new Headers({
+      'Content-Type':'application/x-www-form-urlencoded',
+      'Accept':'application/json'
+    });
+    logDebug('refreshAccessToken fetch', {
+      hasRefreshToken: Boolean(bungieTokens?.refreshToken)
+    });
+    let resp;
+    try{
+      resp = await fetch(BUNGIE_TOKEN_URL, {
+        method:'POST',
+        headers,
+        body
+      });
+    }catch(err){
+      logDebug('refreshAccessToken networkError', { error: err?.message || err });
+      throw new Error(formatBungieNetworkError(err));
+    }
+    const data = await resp.json().catch(()=>null);
+    if(!resp.ok || !data?.access_token){
+      const rawMsg = data?.error_description || data?.Message || `HTTP ${resp.status}`;
+      const msg = rawMsg === 'OriginHeaderDoesNotMatchKey'
+        ? 'OriginHeaderDoesNotMatchKey: Add https://erebusares.github.io to the Origin Header whitelist for your Bungie application and redeploy.'
+        : rawMsg;
+      clearBungieTokens(false);
+      logDebug('refreshAccessToken failed', { status: resp.status, message: msg });
+      throw new Error(msg);
+    }
+    bungieTokens.accessToken = data.access_token;
+    bungieTokens.accessTokenExpires = Date.now() + (Number(data.expires_in || 0) * 1000);
+    if(data.refresh_token){
+      bungieTokens.refreshToken = data.refresh_token;
+    }
+    if(data.refresh_expires_in){
+      bungieTokens.refreshTokenExpires = Date.now() + Number(data.refresh_expires_in) * 1000;
+    }
+    if(data.token_type){
+      bungieTokens.tokenType = data.token_type;
+    }
+    if(data.membership_id){
+      bungieTokens.membershipId = data.membership_id;
+    }
+    if(data.membership_type != null){
+      bungieTokens.membershipType = data.membership_type;
+    }
+    saveBungieTokens();
+    logDebug('refreshAccessToken success', {
+      accessExpiresIn: Number(data.expires_in || 0),
+      refreshExpiresIn: Number(data.refresh_expires_in || 0)
+    });
+  }
+
+  function formatBungieNetworkError(err){
+    const rawMessage = (err?.message || '').trim();
+    const normalized = rawMessage || 'Network request failed.';
+    const lowered = normalized.toLowerCase();
+    if(lowered.includes('failed to fetch') || lowered.includes('networkerror') || lowered.includes('load failed')){
+      let currentOrigin = '';
+      try{
+        currentOrigin = window.location?.origin || '';
+      }catch(_){
+        currentOrigin = '';
+      }
+      const isOpaque = !currentOrigin || currentOrigin === 'null';
+      if(isOpaque){
+        return `Network error contacting Bungie. Serve this page from ${BUNGIE_ALLOWED_ORIGIN} or another web server and add that origin to your Bungie application's Origin Header whitelist before trying again.`;
+      }
+      if(currentOrigin !== BUNGIE_ALLOWED_ORIGIN){
+        return `Network error contacting Bungie from ${currentOrigin}. Add this origin (without a trailing slash) to the Bungie application's Origin Header whitelist alongside ${BUNGIE_ALLOWED_ORIGIN}, publish the change, and reload before trying again.`;
+      }
+      return `Network error contacting Bungie from ${currentOrigin}. Confirm this origin appears in the Bungie application's Origin Header whitelist and try again in a few moments.`;
+    }
+    return normalized;
+  }
+
+  function formatBungieError(data, status){
+    const rawMessage = data?.Message || data?.message || data?.error_description || data?.error || `HTTP ${status}`;
+    const errorStatus = data?.ErrorStatus || data?.Error || data?.error;
+    const normalized = (rawMessage || '').trim();
+    const originMismatch = normalized === 'Origin header does not match the provided API key.'
+      || normalized === 'OriginHeaderDoesNotMatchKey'
+      || errorStatus === 'OriginHeaderDoesNotMatchKey';
+    if(originMismatch){
+      let currentOrigin = '';
+      try{
+        currentOrigin = window.location?.origin || '';
+      }catch(_){
+        currentOrigin = '';
+      }
+      const isOpaqueOrigin = !currentOrigin || currentOrigin === 'null';
+      if(isOpaqueOrigin){
+        return `OriginHeaderDoesNotMatchKey: Bungie rejected the request because local files do not set an Origin header. Serve this page from ${BUNGIE_ALLOWED_ORIGIN} or run it through a local web server (for example, http://localhost:4173) and add that origin to the Bungie application's Origin Header whitelist before retrying.`;
+      }
+      if(currentOrigin !== BUNGIE_ALLOWED_ORIGIN){
+        return `OriginHeaderDoesNotMatchKey: Bungie rejected the request because ${currentOrigin} is not on the API key's Origin Header whitelist. Add both ${currentOrigin} and ${BUNGIE_ALLOWED_ORIGIN} (no trailing slashes) in the Bungie developer portal, publish the change, and reload.`;
+      }
+      return `OriginHeaderDoesNotMatchKey: Bungie rejected the request even though the page is hosted on ${BUNGIE_ALLOWED_ORIGIN}. Double-check the application's Origin Header whitelist in the Bungie developer portal, publish the update, wait a few minutes for it to propagate, and reload before trying again.`;
+    }
+    return normalized || `HTTP ${status}`;
+  }
+
+  async function bungieApiRequest(path, options={}, retry=true){
+    ensureBungieConfigDefaults();
+    const cfg = bungieConfig || {};
+    if(!cfg.apiKey){
+      throw new Error('Bungie API key is missing.');
+    }
+    await ensureAccessToken();
+    const headers = new Headers(options.headers || {});
+    headers.set('X-API-Key', cfg.apiKey);
+    headers.set('Authorization', `${bungieTokens?.tokenType || 'Bearer'} ${bungieTokens?.accessToken || ''}`);
+    headers.set('Accept', 'application/json');
+    const startedAt = Date.now();
+    logDebug('bungieApiRequest', {
+      path,
+      method: options.method || 'GET',
+      retry
+    });
+    let resp;
+    try{
+      resp = await fetch(`${BUNGIE_API_ROOT}${path}`, {
+        method: options.method || 'GET',
+        ...options,
+        headers
+      });
+    }catch(err){
+      logDebug('bungieApiRequest networkError', { path, error: err?.message || err });
+      throw new Error(formatBungieNetworkError(err));
+    }
+    if(resp.status === 401 && retry){
+      logDebug('bungieApiRequest unauthorized', { path });
+      await refreshAccessToken();
+      return bungieApiRequest(path, options, false);
+    }
+    const data = await resp.json().catch(()=>null);
+    if(!resp.ok){
+      const message = formatBungieError(data, resp.status);
+      logDebug('bungieApiRequest failed', {
+        path,
+        status: resp.status,
+        message
+      });
+      throw new Error(message);
+    }
+    if(data?.ErrorCode && data.ErrorCode !== 1){
+      const message = formatBungieError(data, resp.status);
+      logDebug('bungieApiRequest errorCode', {
+        path,
+        status: resp.status,
+        errorCode: data.ErrorCode,
+        message
+      });
+      throw new Error(message);
+    }
+    logDebug('bungieApiRequest success', {
+      path,
+      status: resp.status,
+      elapsedMs: Date.now() - startedAt
+    });
+    return data?.Response;
+  }
+
+  function hashKey(hash){
+    const num = Number(hash);
+    if(Number.isNaN(num)) return String(hash);
+    return String(num >>> 0);
+  }
+
+  async function getManifestIndex(){
+    if(!manifestIndexPromise){
+      manifestIndexPromise = bungieApiRequest('/Destiny2/Manifest/').catch(err => {
+        manifestIndexPromise = null;
+        throw err;
+      });
+    }
+    const manifest = await manifestIndexPromise;
+    if(!manifest){
+      throw new Error('Failed to load Destiny manifest index.');
+    }
+    return manifest;
+  }
+
+  function resolveManifestComponentPath(manifest, componentName){
+    const localePaths = manifest?.jsonWorldComponentContentPaths || {};
+    const preferredLocales = [];
+    const configuredLocale = String(bungieConfig?.manifestLocale || '').trim().toLowerCase();
+    if(configuredLocale && localePaths[configuredLocale]){
+      preferredLocales.push(configuredLocale);
+    }
+    const browserLocale = (typeof navigator !== 'undefined' && navigator?.language)
+      ? navigator.language.toLowerCase()
+      : '';
+    if(browserLocale){
+      if(localePaths[browserLocale] && !preferredLocales.includes(browserLocale)){
+        preferredLocales.push(browserLocale);
+      }
+      const shortLocale = browserLocale.split('-')[0];
+      if(localePaths[shortLocale] && !preferredLocales.includes(shortLocale)){
+        preferredLocales.push(shortLocale);
+      }
+    }
+    if(localePaths.en && !preferredLocales.includes('en')){
+      preferredLocales.push('en');
+    }
+    for(const locale of Object.keys(localePaths)){
+      if(!preferredLocales.includes(locale)){
+        preferredLocales.push(locale);
+      }
+    }
+    for(const locale of preferredLocales){
+      const locPaths = localePaths[locale];
+      if(locPaths && locPaths[componentName]){
+        return { path: locPaths[componentName], locale };
+      }
+    }
+    return { path: null, locale: null };
+  }
+
+  async function loadManifestComponent(componentName){
+    if(manifestComponentCache.has(componentName)){
+      return manifestComponentCache.get(componentName);
+    }
+    if(manifestComponentPromises.has(componentName)){
+      return manifestComponentPromises.get(componentName);
+    }
+    const promise = (async () => {
+      const manifest = await getManifestIndex();
+      const { path, locale } = resolveManifestComponentPath(manifest, componentName);
+      if(!path){
+        throw new Error(`Manifest component path missing for ${componentName}`);
+      }
+      const url = `https://www.bungie.net${path}`;
+      const response = await fetch(url);
+      if(!response.ok){
+        throw new Error(`Failed to load manifest component ${componentName}: ${response.status}`);
+      }
+      const json = await response.json();
+      manifestComponentCache.set(componentName, json);
+      logDebug('manifest component loaded', {
+        component: componentName,
+        locale,
+        entryCount: json && typeof json === 'object' ? Object.keys(json).length : null
+      });
+      return json;
+    })();
+    manifestComponentPromises.set(componentName, promise);
+    try{
+      const data = await promise;
+      manifestComponentPromises.delete(componentName);
+      return data;
+    }catch(err){
+      manifestComponentPromises.delete(componentName);
+      throw err;
+    }
+  }
+
+  async function getInventoryItemDefinition(hash){
+    const key = hashKey(hash);
+    if(manifestCache.inventoryItem.has(key)){
+      return manifestCache.inventoryItem.get(key);
+    }
+    const component = await loadManifestComponent(MANIFEST_COMPONENT_INVENTORY_ITEM);
+    const def = component?.[key] || null;
+    if(def){
+      manifestCache.inventoryItem.set(key, def);
+    }else{
+      logDebug('inventory definition missing', { hash: key });
+    }
+    return def;
+  }
+
+  async function getSocketTypeDefinition(hash){
+    const key = hashKey(hash);
+    if(manifestCache.socketType.has(key)){
+      return manifestCache.socketType.get(key);
+    }
+    const component = await loadManifestComponent(MANIFEST_COMPONENT_SOCKET_TYPE);
+    const def = component?.[key] || null;
+    if(def){
+      manifestCache.socketType.set(key, def);
+    }else{
+      logDebug('socket type definition missing', { hash: key });
+    }
+    return def;
+  }
+
+  async function prefetchInventoryItemDefinitions(hashes, concurrency = 10){
+    if(!Array.isArray(hashes) || hashes.length === 0){
+      return;
+    }
+    logDebug('prefetchInventoryItemDefinitions start', {
+      requested: hashes.length,
+      concurrency
+    });
+    const queue = [];
+    const seen = new Set();
+    for(const rawHash of hashes){
+      const key = hashKey(rawHash);
+      if(!key || seen.has(key)){
+        continue;
+      }
+      seen.add(key);
+      if(manifestCache.inventoryItem.has(key)){
+        continue;
+      }
+      queue.push(key);
+    }
+    const totalQueued = queue.length;
+    while(queue.length){
+      const batch = queue.splice(0, Math.max(1, concurrency));
+      await Promise.all(batch.map(async hash => {
+        try{
+          await getInventoryItemDefinition(hash);
+        }catch(err){
+          console.error('Failed to preload manifest definition', hash, err);
+          logDebug('prefetchInventoryItemDefinitions error', { hash, error: err?.message || err });
+          throw err;
+        }
+      }));
+    }
+    logDebug('prefetchInventoryItemDefinitions complete', {
+      requested: hashes.length,
+      queued: totalQueued
+    });
+  }
+
+  async function transformProfileToRows(profile){
+    const itemsMap = new Map();
+    logDebug('transformProfileToRows start', {
+      hasProfileInventory: Array.isArray(profile?.profileInventory?.data?.items),
+      hasCharacterInventories: Boolean(profile?.characterInventories?.data),
+      hasCharacterEquipment: Boolean(profile?.characterEquipment?.data)
+    });
+    const addItems = (items)=>{
+      if(!Array.isArray(items)) return;
+      for(const item of items){
+        if(!item || !item.itemInstanceId) continue;
+        if(itemsMap.has(item.itemInstanceId)) continue;
+        itemsMap.set(item.itemInstanceId, item);
+      }
+    };
+    addItems(profile?.profileInventory?.data?.items);
+    const charInventories = profile?.characterInventories?.data || {};
+    for(const inv of Object.values(charInventories)){
+      addItems(inv?.items);
+    }
+    const charEquipment = profile?.characterEquipment?.data || {};
+    for(const equip of Object.values(charEquipment)){
+      addItems(equip?.items);
+    }
+    logDebug('transformProfileToRows itemsCollected', { totalItems: itemsMap.size });
+    if(itemsMap.size === 0) return [];
+    const instances = profile?.itemComponents?.instances?.data || {};
+    const statsByItem = profile?.itemComponents?.stats?.data || {};
+    const socketsByItem = profile?.itemComponents?.sockets?.data || {};
+    const relevantItems = [];
+    for(const [instanceId, item] of itemsMap.entries()){
+      const bucketKey = hashKey(item.bucketHash);
+      let isArmorCandidate = !!ARMOR_BUCKET_HASH_TO_TYPE[bucketKey];
+      if(!isArmorCandidate){
+        const statMap = statsByItem?.[instanceId]?.stats;
+        if(statMap){
+          for(const statHash of Object.keys(statMap)){
+            if(STAT_HASH_TO_LABEL[hashKey(statHash)]){
+              isArmorCandidate = true;
+              break;
+            }
+          }
+        }
+      }
+      if(!isArmorCandidate){
+        const energy = instances?.[instanceId]?.energy;
+        if(energy && (Number.isFinite(energy?.energyCapacity) || Number.isFinite(energy?.energyLevel))){
+          isArmorCandidate = true;
+        }
+      }
+      if(isArmorCandidate){
+        relevantItems.push(item);
+      }
+    }
+    logDebug('transformProfileToRows relevantItems', { count: relevantItems.length });
+    if(relevantItems.length === 0) return [];
+    const uniqueItemKeys = new Set();
+    const uniqueItemHashes = [];
+    const plugKeys = new Set();
+    const plugHashList = [];
+    for(const item of relevantItems){
+      const itemKey = hashKey(item.itemHash);
+      if(itemKey && !uniqueItemKeys.has(itemKey)){
+        uniqueItemKeys.add(itemKey);
+        uniqueItemHashes.push(item.itemHash);
+      }
+      const sockets = socketsByItem?.[item.itemInstanceId]?.sockets;
+      if(!Array.isArray(sockets)) continue;
+      for(const socket of sockets){
+        if(!socket || socket?.plugged?.enabled === false) continue;
+        const plugHash = getSocketPlugHash(socket);
+        const plugKey = plugHash != null ? hashKey(plugHash) : null;
+        if(!plugKey || plugKeys.has(plugKey)) continue;
+        plugKeys.add(plugKey);
+        plugHashList.push(plugHash);
+      }
+    }
+    logDebug('transformProfileToRows manifestPrefetch', {
+      itemDefinitions: uniqueItemHashes.length,
+      plugDefinitions: plugHashList.length
+    });
+    await prefetchInventoryItemDefinitions(uniqueItemHashes.concat(plugHashList));
+    const rows = [];
+    for(const item of relevantItems){
+      const def = await getInventoryItemDefinition(item.itemHash);
+      const sockets = socketsByItem?.[item.itemInstanceId]?.sockets || [];
+      const row = await buildRowFromDefinition(
+        item,
+        def,
+        instances[item.itemInstanceId],
+        statsByItem[item.itemInstanceId]?.stats || {},
+        sockets
+      );
+      if(row) rows.push(row);
+    }
+    logDebug('transformProfileToRows complete', { rows: rows.length });
+    return rows;
+  }
+
+  function getSocketPlugHash(socket){
+    if(!socket) return null;
+    const plugHash = socket?.plugged?.plugItemHash
+      ?? socket?.plugged?.plugHash
+      ?? socket?.plugHash
+      ?? socket?.plugItemHash;
+    return plugHash != null ? plugHash : null;
+  }
+
+  function toFiniteNumber(value){
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+
+  function deriveEnergyTierInfo(energy){
+    if(!energy){
+      return {
+        tier: 0,
+        source: null,
+        upgradeLevel: null,
+        level: null,
+        capacity: null,
+        used: null,
+        unused: null
+      };
+    }
+    const level = toFiniteNumber(energy?.energyLevel);
+    const capacity = toFiniteNumber(energy?.energyCapacity);
+    const usedRaw = toFiniteNumber(energy?.energyUsed);
+    const unused = toFiniteNumber(energy?.energyUnused);
+
+    const used = Number.isFinite(usedRaw) ? Math.max(0, Math.min(usedRaw, 10)) : null;
+    const usedFromCapacity = (Number.isFinite(capacity) && Number.isFinite(unused))
+      ? Math.max(0, Math.min(capacity - unused, 10))
+      : null;
+
+    const usedPlusUnused = (used !== null && Number.isFinite(unused))
+      ? Math.max(0, used + Math.max(0, Math.min(unused, 10)))
+      : null;
+
+    let upgradeLevel = null;
+    let source = null;
+
+    const assignIfUnset = (value, valueSource) => {
+      if(upgradeLevel !== null) return;
+      if(!Number.isFinite(value)) return;
+      upgradeLevel = value;
+      source = valueSource;
+    };
+
+    assignIfUnset(used, 'energyUsed');
+    assignIfUnset(level, 'energyLevel');
+    assignIfUnset(usedFromCapacity, 'energyCapacityMinusUnused');
+    assignIfUnset(usedPlusUnused, 'energyUsedPlusUnused');
+    assignIfUnset(capacity, 'energyCapacity');
+
+    if(upgradeLevel !== null){
+      upgradeLevel = Math.max(0, Math.min(upgradeLevel, 10));
+    }
+
+    let tier = 0;
+    if(upgradeLevel !== null){
+      tier = Math.ceil(Math.max(0, upgradeLevel) / 2);
+      if(tier < 0) tier = 0;
+      if(tier > 5) tier = 5;
+      if(upgradeLevel > 0 && tier === 0){
+        tier = 1;
+      }
+    }
+
+    return {
+      tier,
+      source,
+      upgradeLevel,
+      level,
+      capacity,
+      used,
+      unused
+    };
+  }
+
+  // Destiny Item Manager removes every socket-provided stat bonus except for intrinsic
+  // or frame plugs when it has to derive base stats manually. We mostly rely on Bungie's
+  // provided `stat.base` values, but we still need this filter for the few cases where
+  // the API omits those base numbers and we have to fall back to subtraction.
+  function shouldSubtractPlugFromBaseStats(def, plugStats, socketCategoryHash){
+    if(!plugStats || plugStats.size === 0) return false;
+    if(Number.isFinite(socketCategoryHash)){
+      if(ARMOR_BASE_SOCKET_CATEGORY_HASHES.has(socketCategoryHash)){
+        return false;
+      }
+      if(ARMOR_MOD_SOCKET_CATEGORY_HASHES.has(socketCategoryHash)){
+        return true;
+      }
+    }
+    if(!def) return true;
+    const plugCategoryHash = Number(def?.plug?.plugCategoryHash);
+    if(Number.isFinite(plugCategoryHash)){
+      if(ARMOR_INTRINSIC_PLUG_CATEGORY_HASHES.has(plugCategoryHash)){
+        return false;
+      }
+      if(ARMOR_MOD_PLUG_CATEGORY_HASHES.has(plugCategoryHash)){
+        return true;
+      }
+    }
+    const plugCat = String(def?.plug?.plugCategoryIdentifier || '').toLowerCase();
+    if(plugCat){
+      if(plugCat === 'intrinsics' || plugCat.startsWith('intrinsics.')) return false;
+      if(plugCat.startsWith('frames')) return false;
+      if(plugCat.includes('ornament') || plugCat.includes('cosmetic') || plugCat.includes('spawnfx')) return false;
+      if(plugCat.includes('tracker')) return false;
+      if(plugCat.includes('armor_mod')) return true;
+      if(plugCat.includes('enhancements')) return true;
+      if(plugCat.includes('armor_tiering')) return true;
+      if(plugCat.includes('tuning')) return true;
+    }
+    if(isMasterworkStatPlug(def)){
+      return true;
+    }
+    const itemCategories = Array.isArray(def?.itemCategoryHashes) ? def.itemCategoryHashes : [];
+    for(const catHash of itemCategories){
+      if(ARMOR_MOD_ITEM_CATEGORY_HASHES.has(Number(catHash))){
+        return true;
+      }
+    }
+    const typeName = String(def?.itemTypeDisplayName || '').toLowerCase();
+    if(typeName.includes('ornament') || typeName.includes('shader') || typeName.includes('projection')) return false;
+    if(typeName.includes('mod')) return true;
+    const displayName = String(def?.displayProperties?.name || '').toLowerCase();
+    if(displayName.includes('ornament') || displayName.includes('shader')) return false;
+    if(displayName.includes('mod')) return true;
+    // Default to subtracting when a plug adjusts stats so new armor mod categories
+    // automatically roll into the subtraction path unless they are explicitly
+    // identified as intrinsic/cosmetic sockets above.
+    return true;
+  }
+
+  function isIntrinsicPlugForBaseStats(def, socketCategoryHash){
+    if(Number.isFinite(socketCategoryHash) && ARMOR_BASE_SOCKET_CATEGORY_HASHES.has(socketCategoryHash)){
+      return true;
+    }
+    if(!def) return false;
+    const plugCategoryHash = Number(def?.plug?.plugCategoryHash);
+    if(Number.isFinite(plugCategoryHash) && ARMOR_INTRINSIC_PLUG_CATEGORY_HASHES.has(plugCategoryHash)){
+      return true;
+    }
+    const plugCat = String(def?.plug?.plugCategoryIdentifier || '').toLowerCase();
+    if(plugCat){
+      if(plugCat === 'intrinsics' || plugCat.startsWith('intrinsics.')) return true;
+      if(plugCat.startsWith('frames')) return true;
+    }
+    return false;
+  }
+
+  function isMasterworkStatPlug(def){
+    if(!def) return false;
+    const plugCat = String(def?.plug?.plugCategoryIdentifier || '').toLowerCase();
+    if(plugCat && plugCat.includes('masterwork')) return true;
+    const typeName = String(def?.itemTypeDisplayName || '').toLowerCase();
+    if(typeName.includes('masterwork')) return true;
+    const displayName = String(def?.displayProperties?.name || '').toLowerCase();
+    if(displayName.includes('masterwork')) return true;
+    return false;
+  }
+
+  function getPlugStatValues(socket, plugDef){
+    const values = new Map();
+    const addStat = (label, amount, overwriteExisting = false) => {
+      if(!label) return;
+      const numeric = Number(amount ?? 0);
+      if(!Number.isFinite(numeric) || numeric === 0) return;
+      if(!values.has(label) || overwriteExisting){
+        values.set(label, numeric);
+      }else{
+        values.set(label, values.get(label) + numeric);
+      }
+    };
+
+    if(plugDef){
+      const invStats = Array.isArray(plugDef?.investmentStats) ? plugDef.investmentStats : [];
+      for(const stat of invStats){
+        const statKey = hashKey(stat?.statTypeHash);
+        const label = STAT_HASH_TO_LABEL[statKey];
+        addStat(label, stat?.value, false);
+      }
+    }
+
+    const plugStats = socket?.plugged?.stats;
+    if(plugStats && typeof plugStats === 'object'){
+      for(const [hash, entry] of Object.entries(plugStats)){
+        const statKey = hashKey(hash);
+        const label = STAT_HASH_TO_LABEL[statKey];
+        if(!label) continue;
+        const raw = typeof entry === 'object' && entry !== null ? entry.value : entry;
+        if(values.has(label)){ // avoid double counting identical manifest values
+          const numeric = Number(raw ?? 0);
+          if(Number.isFinite(numeric) && Math.abs(values.get(label) - numeric) > 0.0001){
+            values.set(label, numeric);
+          }
+          continue;
+        }
+        addStat(label, raw, true);
+      }
+    }
+    return values;
+  }
+
+  async function getStatAdjustmentsFromSockets(sockets, socketDefs, options={}){
+    const adjustments = {};
+    const masterworkAdjustments = {};
+    const baseContributions = {};
+    let hasRecognizedStatPlug = false;
+    let hasRecognizedMasterworkPlug = false;
+    const collectDetails = Boolean(options?.collectDetails);
+    const debugDetails = collectDetails ? [] : null;
+    if(!Array.isArray(sockets)){
+      return {
+        adjustments,
+        masterworkAdjustments,
+        baseContributions,
+        hasRecognizedStatPlug,
+        hasRecognizedMasterworkPlug,
+        details: debugDetails || undefined
+      };
+    }
+    for(let index = 0; index < sockets.length; index++){
+      const socket = sockets[index];
+      if(!socket) continue;
+      const socketDef = Array.isArray(socketDefs) ? socketDefs[index] : null;
+      let socketCategoryHash = null;
+      const socketTypeHash = socketDef?.socketTypeHash;
+      if(socketTypeHash != null){
+        try{
+          const socketTypeDef = await getSocketTypeDefinition(socketTypeHash);
+          const categoryHash = Number(socketTypeDef?.socketCategoryHash);
+          if(Number.isFinite(categoryHash)){
+            socketCategoryHash = categoryHash;
+          }
+        }catch(err){
+          console.warn('Failed to load socket type definition for stat adjustments', socketTypeHash, err);
+        }
+      }
+      const plugHash = getSocketPlugHash(socket);
+      if(plugHash == null) continue;
+      const enabledFlags = [
+        socket?.plugged?.enabled,
+        socket?.plugged?.isEnabled,
+        socket?.isEnabled,
+        socket?.enabled
+      ];
+      const explicitFlags = enabledFlags.filter(flag => flag === true || flag === false);
+      if(explicitFlags.length > 0 && explicitFlags.every(flag => flag === false)) continue;
+      let plugDef = manifestCache.inventoryItem.get(hashKey(plugHash));
+      if(!plugDef){
+        try{
+          plugDef = await getInventoryItemDefinition(plugHash);
+        }catch(err){
+          console.warn('Failed to load plug definition for stat adjustments', plugHash, err);
+          plugDef = undefined;
+        }
+      }
+      const plugStats = getPlugStatValues(socket, plugDef);
+      if(plugStats.size === 0) continue;
+      const treatAsIntrinsic = isIntrinsicPlugForBaseStats(plugDef, socketCategoryHash);
+      let subtract = !treatAsIntrinsic;
+      if(subtract){
+        const heuristic = shouldSubtractPlugFromBaseStats(plugDef, plugStats, socketCategoryHash);
+        if(heuristic === false && plugStats.size > 0){
+          subtract = true;
+        }else{
+          subtract = heuristic;
+        }
+      }
+      const isMasterwork = isMasterworkStatPlug(plugDef);
+      if(subtract){
+        hasRecognizedStatPlug = true;
+        if(isMasterwork){
+          hasRecognizedMasterworkPlug = true;
+        }
+        for(const [label, value] of plugStats.entries()){
+          adjustments[label] = (adjustments[label] || 0) + value;
+          if(isMasterwork){
+            masterworkAdjustments[label] = (masterworkAdjustments[label] || 0) + value;
+          }
+        }
+      }else if(treatAsIntrinsic){
+        for(const [label, value] of plugStats.entries()){
+          baseContributions[label] = (baseContributions[label] || 0) + value;
+        }
+      }
+      if(debugDetails){
+        const statsObject = {};
+        for(const [label, value] of plugStats.entries()){
+          statsObject[label] = value;
+        }
+        debugDetails.push({
+          plugHash: plugHash != null ? hashKey(plugHash) : null,
+          plugName: plugDef?.displayProperties?.name || null,
+          socketCategoryHash: socketCategoryHash != null ? Number(socketCategoryHash) : null,
+          plugCategoryIdentifier: plugDef?.plug?.plugCategoryIdentifier || null,
+          subtract,
+          intrinsic: treatAsIntrinsic,
+          isMasterwork,
+          stats: statsObject,
+          enabledFlags: explicitFlags
+        });
+      }
+    }
+    return {
+      adjustments,
+      masterworkAdjustments,
+      baseContributions,
+      hasRecognizedStatPlug,
+      hasRecognizedMasterworkPlug,
+      details: debugDetails || undefined
+    };
+  }
+
+  async function buildRowFromDefinition(item, def, instance, stats, sockets){
+    if(!def || !def.inventory) return null;
+    if(def.itemType !== 2) return null;
+    if(def.classType != null && def.classType > 2 && def.classType !== 3 && def.classType !== 4) return null;
+    const bucketKey = hashKey(def.inventory.bucketTypeHash);
+    if(!ARMOR_BUCKET_HASH_TO_TYPE[bucketKey]) return null;
+    const className = CLASS_BY_TYPE[def.classType] || 'Any';
+    const isClassItem = bucketKey === String(1585787867);
+    const typeName = isClassItem
+      ? (classItemByClass[className] || def.itemTypeDisplayName || 'Class Item')
+      : (def.itemTypeDisplayName || ARMOR_BUCKET_HASH_TO_TYPE[bucketKey] || 'Armor');
+    const energy = instance?.energy;
+    const energyInfo = deriveEnergyTierInfo(energy);
+    const energyTierValue = Number.isFinite(energyInfo?.tier) ? energyInfo.tier : null;
+    const usedEnergy = Number.isFinite(energyInfo?.used) ? energyInfo.used : null;
+    const upgradeLevel = Number.isFinite(energyInfo?.upgradeLevel) ? energyInfo.upgradeLevel : null;
+    const capacityLevel = Number.isFinite(energyInfo?.capacity) ? energyInfo.capacity : null;
+    const currentEnergy = upgradeLevel ?? capacityLevel ?? usedEnergy ?? null;
+    const tierEnergySource = energyInfo?.source || null;
+    const row = {
+      Id: normId(item.itemInstanceId || item.itemHash),
+      Name: def?.displayProperties?.name || 'Unknown Item',
+      Type: typeName,
+      Equippable: className === 'Unknown' ? 'Any' : className,
+      Rarity: def?.inventory?.tierTypeName || '',
+      Tag: '',
+      Power: instance?.primaryStat?.value ?? '',
+      Tier: 0,
+      'Total (Base)': 0
+    };
+    const socketDefs = Array.isArray(def?.sockets?.socketEntries) ? def.sockets.socketEntries : [];
+    const collectDebug = debugState.armorSamples.length < ARMOR_DEBUG_SAMPLE_LIMIT;
+    const socketDetails = await getStatAdjustmentsFromSockets(sockets, socketDefs, { collectDetails: collectDebug });
+    const hasRecognizedMasterworkPlug = Boolean(socketDetails?.hasRecognizedMasterworkPlug);
+    const statDebug = collectDebug ? {} : null;
+    const itemStateValue = Number(instance?.state);
+    const isMasterworkedByState = Number.isFinite(itemStateValue) && (itemStateValue & DESTINY_ITEM_STATE_MASTERWORK) === DESTINY_ITEM_STATE_MASTERWORK;
+    const isMasterworked = isMasterworkedByState
+      || (Number.isFinite(capacityLevel) && capacityLevel >= 10)
+      || (Number.isFinite(upgradeLevel) && upgradeLevel >= 10);
+    for(const [hash,label] of Object.entries(STAT_HASH_TO_LABEL)){
+      const stat = stats?.[hash];
+      const value = Number(stat?.value);
+      const numericValue = Number.isFinite(value) ? value : null;
+      const totalAdjustmentRaw = Number(socketDetails?.adjustments?.[label]);
+      const totalAdjustment = Number.isFinite(totalAdjustmentRaw) ? totalAdjustmentRaw : 0;
+      const masterworkContributionRaw = Number(socketDetails?.masterworkAdjustments?.[label]);
+      const recognizedMasterworkBonus = Number.isFinite(masterworkContributionRaw) && Math.abs(masterworkContributionRaw) > 0.001 ? masterworkContributionRaw : 0;
+      const fallbackMasterworkBonus = (!recognizedMasterworkBonus && isMasterworked && !hasRecognizedMasterworkPlug) ? 2 : 0;
+      const socketBaseRaw = Number(socketDetails?.baseContributions?.[label]);
+      const socketBase = Number.isFinite(socketBaseRaw) ? socketBaseRaw : null;
+      const fallbackMasterworkToSubtract = (!recognizedMasterworkBonus && fallbackMasterworkBonus) ? fallbackMasterworkBonus : 0;
+      const adjustmentToSubtract = totalAdjustment + fallbackMasterworkToSubtract;
+
+      const apiBase = Number(stat?.base);
+      const apiInvestment = Number(stat?.investmentValue);
+      let manualBase = null;
+      const hasMeaningfulAdjustment = Number.isFinite(adjustmentToSubtract) && Math.abs(adjustmentToSubtract) > 0.0001;
+      if(Number.isFinite(numericValue) && Number.isFinite(adjustmentToSubtract)){
+        const candidate = numericValue - adjustmentToSubtract;
+        if(Number.isFinite(candidate)){
+          manualBase = Math.max(0, candidate);
+        }
+      }
+
+      let baseValue = null;
+      let baseSource = 'fallback-zero';
+
+      if(Number.isFinite(apiBase)){
+        baseValue = apiBase;
+        baseSource = 'apiBase';
+      }else if(Number.isFinite(apiInvestment)){
+        baseValue = apiInvestment;
+        baseSource = 'apiInvestment';
+      }
+
+      if(Number.isFinite(manualBase) && hasMeaningfulAdjustment){
+        if(baseValue == null || manualBase < baseValue - 0.0001){
+          baseValue = manualBase;
+          baseSource = 'derivedAdjustments';
+        }
+      }else if(baseValue === null && Number.isFinite(socketBase)){
+        baseValue = socketBase;
+        baseSource = 'socketIntrinsic';
+      }
+
+      if(baseValue === null){
+        if(Number.isFinite(numericValue)){
+          baseValue = numericValue;
+          baseSource = 'current';
+        }else{
+          baseValue = 0;
+          baseSource = 'fallback-zero';
+        }
+      }
+
+      if(Number.isFinite(numericValue)){
+        if(Number.isFinite(totalAdjustment) && totalAdjustment < 0){
+          // Allow base stats to exceed the current stat when penalties are equipped.
+        }else{
+          baseValue = Math.min(baseValue, numericValue);
+        }
+      }
+
+      const roundedBase = Math.max(0, Math.round(baseValue));
+      row[label] = roundedBase;
+
+      if(statDebug){
+        statDebug[label] = {
+          current: Number.isFinite(numericValue) ? numericValue : null,
+          socketBase,
+          manualBase: Number.isFinite(manualBase) ? manualBase : null,
+          apiBase: Number.isFinite(apiBase) ? apiBase : null,
+          apiInvestment: Number.isFinite(apiInvestment) ? apiInvestment : null,
+          totalAdjustment,
+          adjustmentToSubtract: Number.isFinite(adjustmentToSubtract) ? adjustmentToSubtract : null,
+          hasMeaningfulAdjustment,
+          recognizedMasterworkBonus,
+          fallbackMasterworkBonus,
+          fallbackMasterworkApplied: fallbackMasterworkToSubtract,
+          baseSource,
+          computedBase: roundedBase
+        };
+      }
+    }
+    let totalBase = 0;
+    for(const label of Object.values(STAT_HASH_TO_LABEL)){
+      const value = Number(row[label]);
+      if(Number.isFinite(value)){
+        totalBase += value;
+      }
+    }
+    row['Total (Base)'] = totalBase;
+    const statTier = Math.max(0, Math.floor(totalBase / 10));
+    row.Tier = statTier;
+    if(statDebug){
+      const capacityNum = Number.isFinite(energyInfo?.capacity) ? energyInfo.capacity : Number(energy?.energyCapacity);
+      const usedNum = Number.isFinite(energyInfo?.used) ? energyInfo.used : Number(energy?.energyUsed);
+      const unusedNum = Number.isFinite(energyInfo?.unused) ? energyInfo.unused : Number(energy?.energyUnused);
+      const levelNum = Number.isFinite(energyInfo?.level) ? energyInfo.level : Number(energy?.energyLevel);
+      const sample = {
+        name: row.Name,
+        type: row.Type,
+        tier: statTier,
+        totalBase,
+        instanceId: item?.itemInstanceId || null,
+        itemHash: item?.itemHash || null,
+        isMasterworked,
+        masterworkFromState: isMasterworkedByState,
+        hasRecognizedMasterworkPlug,
+        energy: {
+          capacity: Number.isFinite(capacityNum) ? capacityNum : null,
+          used: Number.isFinite(usedNum) ? usedNum : null,
+          unused: Number.isFinite(unusedNum) ? unusedNum : null,
+          level: Number.isFinite(levelNum) ? levelNum : null,
+          current: Number.isFinite(currentEnergy) ? currentEnergy : null,
+          source: tierEnergySource,
+          derivedTier: Number.isFinite(energyTierValue) ? energyTierValue : null
+        },
+        tierSources: {
+          stats: statTier,
+          energy: Number.isFinite(energyTierValue) ? energyTierValue : null,
+          energySource: tierEnergySource
+        },
+        stats: statDebug,
+        adjustments: socketDetails?.adjustments || {},
+        masterworkAdjustments: socketDetails?.masterworkAdjustments || {},
+        baseContributions: socketDetails?.baseContributions || {},
+        sockets: Array.isArray(socketDetails?.details) ? socketDetails.details : []
+      };
+      recordArmorDebugSample(sample);
+      logDebug('armor row sample', sample);
+    }
+    return row;
+  }
+
+  async function fetchMemberships(){
+    try{
+      logDebug('fetchMemberships start', {});
+      const resp = await bungieApiRequest('/User/GetMembershipsForCurrentUser/');
+      const memberships = Array.isArray(resp?.destinyMemberships) ? resp.destinyMemberships : [];
+      bungieMemberships = memberships.map(m => ({
+        membershipId: m.membershipId,
+        membershipType: m.membershipType,
+        label: formatMembershipLabel(m)
+      }));
+      let selected = null;
+      if(!bungieMemberships.length){
+        setBungieStatus('No Destiny 2 memberships were found for this account.', 'error');
+      }else{
+        selected = bungieMemberships.find(mem => String(mem.membershipType) === String(bungieConfig?.membershipType) && String(mem.membershipId) === String(bungieConfig?.membershipId)) || null;
+        if(!selected){
+          selected = bungieMemberships[0];
+          bungieConfig.membershipType = selected.membershipType;
+          bungieConfig.membershipId = selected.membershipId;
+          saveBungieConfig();
+        }
+        if(selected){
+          setBungieStatus(`Signed in as ${selected.label}.`, 'ok');
+        }else{
+          setBungieStatus('Signed in, but no profile is selected.', 'error');
+        }
+      }
+      renderMembershipOptions();
+      logDebug('fetchMemberships success', {
+        membershipCount: bungieMemberships.length,
+        selected: selected?.label || null
+      });
+      return selected;
+    }catch(err){
+      console.error(err);
+      logDebug('fetchMemberships error', { error: err?.message || err });
+      setBungieStatus('Failed to load memberships: ' + (err?.message || err), 'error');
+    }
+  }
+
+  async function loadArmorFromBungie(options={}){
+    const reason = options?.reason || 'manual';
+    if(bungieIsFetching){
+      logDebug('loadArmorFromBungie skipped', { reason, bungieIsFetching: true });
+      return false;
+    }
+    let success = false;
+    try{
+      bungieIsFetching = true;
+      updateBungieUI();
+      logDebug('loadArmorFromBungie start', { reason });
+      debugState.armorSamples = [];
+      renderDebugArmorSamples();
+      const membership = getSelectedMembership();
+      if(!membership){
+        setBungieStatus('Select a Destiny profile before loading armor.', 'error');
+        logDebug('loadArmorFromBungie missingMembership', {});
+        return false;
+      }
+      const startMessage = reason === 'manual' ? 'Refreshing armor from Bungie…' : 'Loading armor from Bungie…';
+      setBungieStatus(startMessage, 'loading');
+      const profile = await bungieApiRequest(`/Destiny2/${membership.membershipType}/Profile/${membership.membershipId}/?components=${BUNGIE_COMPONENTS}`);
+      const rows = await transformProfileToRows(profile);
+      if(!rows.length){
+        setBungieStatus('No armor items were found for this profile.', 'error');
+        logDebug('loadArmorFromBungie empty', { reason });
+        return false;
+      }
+      STATE.rows = rows;
+      saveRows();
+      render();
+      setUploadHint('Loaded via Bungie API');
+      const successMessage = reason === 'manual'
+        ? `Refreshed ${rows.length} armor items from Bungie.`
+        : `Loaded ${rows.length} armor items from Bungie.`;
+      setBungieStatus(successMessage, 'ok');
+      if(reason === 'auto'){
+        bungieAutoLoadedOnce = true;
+      }
+      logDebug('loadArmorFromBungie success', { reason, itemCount: rows.length });
+      success = true;
+    }catch(err){
+      console.error(err);
+      logDebug('loadArmorFromBungie error', { reason, error: err?.message || err });
+      setBungieStatus('Failed to load armor: ' + (err?.message || err), 'error');
+    }finally{
+      bungieIsFetching = false;
+      updateBungieUI();
+      logDebug('loadArmorFromBungie finished', { reason, success });
+    }
+    return success;
+  }
+
+  async function initBungieIntegration(){
+    logDebug('initBungieIntegration start', {
+      hasRefreshToken: Boolean(bungieTokens?.refreshToken)
+    });
+    updateBungieUI();
+    await handleOAuthRedirect();
+    if(bungieTokens?.refreshToken){
+      const refreshValid = Date.now() < ((bungieTokens.refreshTokenExpires || 0) - 60000);
+      if(!refreshValid){
+        clearBungieTokens(false);
+        setBungieStatus('Your Bungie session expired. Please sign in again.', 'error');
+        logDebug('initBungieIntegration expiredRefresh', {});
+        return;
+      }
+      try{
+        await ensureAccessToken();
+        let membership = getSelectedMembership();
+        if(!membership){
+          membership = await fetchMemberships();
+        }else{
+          renderMembershipOptions();
+        }
+        if(membership && !bungieAutoLoadedOnce){
+          const loaded = await loadArmorFromBungie({ reason: 'auto' });
+          if(!loaded && !bungieStatusEl?.textContent){
+            setBungieStatus(`Signed in as ${membership.label}. Use Refresh armor to try again.`, 'info');
+          }
+          logDebug('initBungieIntegration autoLoadAttempt', { loaded: Boolean(loaded) });
+        }else if(membership && !bungieStatusEl?.textContent){
+          setBungieStatus(`Signed in as ${membership.label}.`, 'ok');
+        }
+      }catch(err){
+        console.error(err);
+        clearBungieTokens(false);
+        setBungieStatus('Your Bungie session expired. Please sign in again.', 'error');
+        logDebug('initBungieIntegration refreshError', { error: err?.message || err });
+      }
+    }else if(!bungieStatusEl?.textContent){
+      setBungieStatus('Sign in with Bungie to sync your armor automatically.', 'info');
+      logDebug('initBungieIntegration awaitingSignIn', {});
+    }
+  }
   // ====== Grouping & Sorting ======
   function clusterRows(filtered){
     const byKey = new Map();
@@ -393,11 +2351,16 @@ out.sort((a, b) => {
 
   // ====== Render ======
   function render(){
-  updateShadowColor(); 
+    updateShadowColor();
     const tolEl=document.getElementById('tol'); if(tolEl) tolEl.value = STATE.tol;
     initFilters();
 
     const grouped = getFiltered();
+    if(debugState.lastRenderCount !== grouped.length){
+      debugState.lastRenderCount = grouped.length;
+      logDebug('render rows', { visibleRows: grouped.length });
+    }
+    updateDebugSnapshot();
 
     // Build group->ids for copy-all
     const groupToIds = new Map();
@@ -505,6 +2468,31 @@ out.sort((a, b) => {
   }
 
   // ====== Events ======
+  initDebugPanel();
+
+  bungieStatusEl = document.getElementById('bungieStatus');
+  bungieMembershipSelect = document.getElementById('membershipSelect');
+  bungieMembershipWrap = document.getElementById('membershipSelectWrap');
+  bungieLoginBtn = document.getElementById('bungieLogin');
+  bungieRefreshBtn = document.getElementById('bungieRefresh');
+  bungieLogoutBtn = document.getElementById('bungieLogout');
+
+  if(bungieLoginBtn) bungieLoginBtn.addEventListener('click', () => startBungieAuth());
+  if(bungieRefreshBtn) bungieRefreshBtn.addEventListener('click', () => loadArmorFromBungie({ reason: 'manual' }));
+  if(bungieLogoutBtn) bungieLogoutBtn.addEventListener('click', () => { clearBungieTokens(true); });
+  if(bungieMembershipSelect){
+    bungieMembershipSelect.addEventListener('change', (event) => {
+      const value = event.target.value;
+      if(!value) return;
+      const [type, id] = value.split(':');
+      bungieConfig.membershipType = Number(type);
+      bungieConfig.membershipId = id;
+      saveBungieConfig();
+      updateBungieUI();
+      loadArmorFromBungie({ reason: 'auto' });
+    });
+  }
+
   const fileInput = document.getElementById('file');
   const restoreBtn = document.getElementById('restoreBtn');
   const clearBtn = document.getElementById('clearBtn');
@@ -599,6 +2587,7 @@ out.sort((a, b) => {
 }
 
   // Initial
+  initBungieIntegration().catch((err)=>{ console.error('Bungie init error', err); });
   const cached = loadRows(); if(cached){ STATE.rows=cached; }
   render();
   updateShadowColor();


### PR DESCRIPTION
## Summary
- only replace Bungie-provided base stats with derived values when plugs actually change the stat and the derived total is lower
- surface the adjustment flag in debug samples for easier troubleshooting
- prioritize energy level readings ahead of capacity so partially-upgraded armor no longer renders as tier five

## Testing
- Not run (Bungie OAuth requires external services unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cb245d5404832d911c826a883aa6b5