### PR TITLE
Prioritize energy level when deriving upgrade tier

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -1658,11 +1658,11 @@
       source = valueSource;
     };
 
-    assignIfUnset(used, 'energyUsed');
-    assignIfUnset(usedFromCapacity, 'energyCapacityMinusUnused');
-    assignIfUnset(usedPlusUnused, 'energyUsedPlusUnused');
     assignIfUnset(level, 'energyLevel');
     assignIfUnset(capacity, 'energyCapacity');
+    assignIfUnset(usedFromCapacity, 'energyCapacityMinusUnused');
+    assignIfUnset(usedPlusUnused, 'energyUsedPlusUnused');
+    assignIfUnset(used, 'energyUsed');
 
     if(upgradeLevel !== null){
       upgradeLevel = Math.max(0, Math.min(upgradeLevel, 10));


### PR DESCRIPTION
## Summary
- prefer energy level and level-based heuristics when deriving upgrade tier
- fall back to mod-based energy usage only when level information is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfae2611c4832db3f7411575dd5e31