### PR TITLE
Fix intrinsic plug stat subtraction heuristic

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -1875,10 +1875,10 @@
       let subtract = !treatAsIntrinsic;
       if(subtract){
         const heuristic = shouldSubtractPlugFromBaseStats(plugDef, plugStats, socketCategoryHash);
-        if(heuristic === false && plugStats.size > 0){
+        if(heuristic === false){
+          subtract = false;
+        }else if(heuristic === true){
           subtract = true;
-        }else{
-          subtract = heuristic;
         }
       }
       const isMasterwork = isMasterworkStatPlug(plugDef);


### PR DESCRIPTION
## Summary
- ensure `getStatAdjustmentsFromSockets` respects `false` responses from `shouldSubtractPlugFromBaseStats`
- keep the default subtract behavior for undefined heuristics so intrinsic plugs still populate `baseContributions`

## Testing
- node script exercising `getStatAdjustmentsFromSockets` intrinsic and cosmetic plug scenarios

------
https://chatgpt.com/codex/tasks/task_e_68cfaedb2aa0832daa5992f19a1e24ba