### PR TITLE
Compute base stats by subtracting socket adjustments

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -2203,7 +2203,8 @@
         item,
         def,
         instances[item.itemInstanceId],
-        statsByItem[item.itemInstanceId]?.stats || {}
+        statsByItem[item.itemInstanceId]?.stats || {},
+        sockets
       );
       if(row) rows.push(row);
     }
@@ -2223,6 +2224,38 @@
   function toFiniteNumber(value){
     const numeric = Number(value);
     return Number.isFinite(numeric) ? numeric : null;
+  }
+
+  function normalizeBaseStatValue(value){
+    const numeric = Number(value);
+    if(!Number.isFinite(numeric)){
+      return {
+        valid: false,
+        value: null,
+        rounded: 0,
+        clamped: false,
+        clampedToMin: false,
+        clampedToMax: false
+      };
+    }
+    let normalized = numeric;
+    let clampedToMin = false;
+    let clampedToMax = false;
+    if(normalized < BUNGIE_BASE_STAT_MIN){
+      normalized = BUNGIE_BASE_STAT_MIN;
+      clampedToMin = true;
+    }else if(normalized > BUNGIE_BASE_STAT_MAX){
+      normalized = BUNGIE_BASE_STAT_MAX;
+      clampedToMax = true;
+    }
+    return {
+      valid: true,
+      value: normalized,
+      rounded: Math.round(normalized),
+      clamped: clampedToMin || clampedToMax,
+      clampedToMin,
+      clampedToMax
+    };
   }
 
   function deriveEnergyTierInfo(energy){
@@ -2529,7 +2562,7 @@
     };
   }
 
-  async function buildRowFromDefinition(item, def, instance, stats){
+  async function buildRowFromDefinition(item, def, instance, stats, sockets=[]){
     if(!def || !def.inventory) return null;
     if(def.itemType !== 2) return null;
     if(def.classType != null && def.classType > 2 && def.classType !== 3 && def.classType !== 4) return null;
@@ -2566,6 +2599,18 @@
 
     const collectDebug = debugState.armorSamples.length < ARMOR_DEBUG_SAMPLE_LIMIT;
     const statDebug = collectDebug ? {} : null;
+    const socketInstances = Array.isArray(sockets) ? sockets : [];
+    const socketDefs = Array.isArray(def?.sockets?.socketEntries) ? def.sockets.socketEntries : [];
+    const socketAdjustmentInfo = await getStatAdjustmentsFromSockets(socketInstances, socketDefs, { collectDetails: collectDebug });
+    const socketAdjustmentsByLabel = socketAdjustmentInfo?.adjustments || {};
+    const socketMasterworkByLabel = socketAdjustmentInfo?.masterworkAdjustments || {};
+    const socketBaseContributionsByLabel = socketAdjustmentInfo?.baseContributions || {};
+    const socketAdjustmentDetails = collectDebug && Array.isArray(socketAdjustmentInfo?.details)
+      ? socketAdjustmentInfo.details
+      : null;
+    const socketRecognizedStatPlug = Boolean(socketAdjustmentInfo?.hasRecognizedStatPlug);
+    const socketRecognizedMasterwork = Boolean(socketAdjustmentInfo?.hasRecognizedMasterworkPlug);
+
     let totalBase = 0;
     for(const [hash,label] of Object.entries(STAT_HASH_TO_LABEL)){
       const stat = stats?.[hash];
@@ -2573,9 +2618,17 @@
       const apiInvestment = Number(stat?.investmentValue);
       const current = Number(stat?.value);
 
+      const totalAdjustmentRaw = socketAdjustmentsByLabel?.[label];
+      const masterworkAdjustmentRaw = socketMasterworkByLabel?.[label];
+      const baseContributionRaw = socketBaseContributionsByLabel?.[label];
+      const totalAdjustment = toFiniteNumber(totalAdjustmentRaw);
+      const masterworkAdjustment = toFiniteNumber(masterworkAdjustmentRaw);
+      const baseContribution = toFiniteNumber(baseContributionRaw);
+
+      let baseRaw = null;
       let baseSource = 'fallback-zero';
-      let baseRaw = 0;
-      let socketInfoForStat = null;
+      let usedSocketAdjustmentsForBase = false;
+      let appliedSocketAdjustment = false;
 
       if(Number.isFinite(apiBase)){
         baseRaw = apiBase;
@@ -2584,50 +2637,96 @@
         baseRaw = apiInvestment;
         baseSource = 'apiInvestment';
       }else if(Number.isFinite(current)){
-        baseValue = current;
-        baseSource = 'current';
+        const adjustmentToSubtract = Number.isFinite(totalAdjustment) ? totalAdjustment : 0;
+        baseRaw = current - adjustmentToSubtract;
+        appliedSocketAdjustment = Number.isFinite(totalAdjustment);
+        baseSource = appliedSocketAdjustment ? 'current-minus-sockets' : 'current';
+        usedSocketAdjustmentsForBase = true;
       }else{
-        baseValue = 0;
-        baseSource = 'fallback-zero';
+        baseRaw = 0;
       }
 
-      const roundedBase = Math.max(0, Math.round(baseValue));
-      row[label] = roundedBase;
-      totalBase += roundedBase;
+      const normalization = normalizeBaseStatValue(baseRaw);
+      const finalBase = normalization.valid ? normalization.rounded : 0;
+
+      row[label] = finalBase;
+      totalBase += finalBase;
 
       if(statDebug){
-        statDebug[label] = {
+        let socketDetailsForStat = null;
+        if(socketAdjustmentDetails){
+          const matches = [];
+          for(const detail of socketAdjustmentDetails){
+            const statValue = detail?.stats?.[label];
+            if(statValue === undefined) continue;
+            matches.push({
+              plugHash: detail.plugHash,
+              plugName: detail.plugName,
+              socketCategoryHash: detail.socketCategoryHash,
+              plugCategoryIdentifier: detail.plugCategoryIdentifier,
+              subtract: detail.subtract,
+              intrinsic: detail.intrinsic,
+              isMasterwork: detail.isMasterwork,
+              value: statValue,
+              enabledFlags: detail.enabledFlags
+            });
+          }
+          if(matches.length){
+            socketDetailsForStat = matches;
+          }
+        }
+        let plugSubtractOnly = null;
+        if(Number.isFinite(totalAdjustment) && Number.isFinite(masterworkAdjustment)){
+          plugSubtractOnly = totalAdjustment - masterworkAdjustment;
+        }else if(Number.isFinite(totalAdjustment)){
+          plugSubtractOnly = totalAdjustment;
+        }else if(Number.isFinite(masterworkAdjustment)){
+          plugSubtractOnly = -masterworkAdjustment;
+        }
+        const debugEntry = {
           current: Number.isFinite(current) ? current : null,
           apiBase: Number.isFinite(apiBase) ? apiBase : null,
           apiInvestment: Number.isFinite(apiInvestment) ? apiInvestment : null,
           baseSource,
-          computedBase: finalBase,
-          baseRaw: Number.isFinite(baseRaw) ? baseRaw : null,
+          computedBase: Number.isFinite(baseRaw) ? baseRaw : null,
           baseRounded: normalization.valid ? normalization.rounded : null,
           baseClamped: normalization.valid ? normalization.clamped : false,
           baseClampedToMin: normalization.valid ? normalization.clampedToMin : false,
-          baseClampedToMax: normalization.valid ? normalization.clampedToMax : false
+          baseClampedToMax: normalization.valid ? normalization.clampedToMax : false,
+          socket: {
+            hasData: Array.isArray(socketDetailsForStat) && socketDetailsForStat.length > 0,
+            hasAdjustment: Number.isFinite(totalAdjustment) ? Math.abs(totalAdjustment) > 0.0001 : false,
+            subtract: Number.isFinite(totalAdjustment) ? totalAdjustment : null,
+            masterworkSubtract: Number.isFinite(masterworkAdjustment) ? masterworkAdjustment : null,
+            plugSubtract: plugSubtractOnly,
+            baseContribution: Number.isFinite(baseContribution) ? baseContribution : null,
+            usedForBase: usedSocketAdjustmentsForBase,
+            appliedAdjustment: appliedSocketAdjustment,
+            recognizedStatPlug: socketRecognizedStatPlug,
+            recognizedMasterworkPlug: socketRecognizedMasterwork,
+            rawBase: Number.isFinite(baseRaw) ? baseRaw : null,
+            normalizedBase: normalization.valid ? normalization.value : null,
+            normalizedRounded: normalization.valid ? normalization.rounded : null,
+            normalizedClamped: normalization.valid ? normalization.clamped : false,
+            normalizedClampedToMin: normalization.valid ? normalization.clampedToMin : false,
+            normalizedClampedToMax: normalization.valid ? normalization.clampedToMax : false,
+            details: socketDetailsForStat
+          }
         };
-        if(socketBaseRecoveryTriggered){
-          const socketDetails = socketDebugInfo || null;
-          debugEntry.socket = {
-            hasData: Boolean(socketDetails),
-            hasAdjustment: socketDetails ? socketDetails.hasAdjustment : false,
-            subtract: socketDetails && Number.isFinite(socketDetails.subtract) ? socketDetails.subtract : null,
-            masterworkSubtract: socketDetails && Number.isFinite(socketDetails.masterworkSubtract) ? socketDetails.masterworkSubtract : null,
-            baseContribution: socketDetails && Number.isFinite(socketDetails.baseContribution) ? socketDetails.baseContribution : null,
-            rawBase: socketDetails && Number.isFinite(socketDetails.rawBase) ? socketDetails.rawBase : null,
-            normalizedBase: socketDetails && socketDetails.normalized?.valid ? socketDetails.normalized.value : null,
-            normalizedRounded: socketDetails && socketDetails.normalized?.valid ? socketDetails.normalized.rounded : null,
-            normalizedClamped: socketDetails ? Boolean(socketDetails.normalized?.clamped) : false,
-            usedForBase: socketInfoForStat === socketDetails
-          };
-        }
         statDebug[label] = debugEntry;
       }
     }
 
     row['Total (Base)'] = totalBase;
+
+    const socketDebugSummary = statDebug ? {
+      adjustments: socketAdjustmentsByLabel,
+      masterworkAdjustments: socketMasterworkByLabel,
+      baseContributions: socketBaseContributionsByLabel,
+      hasRecognizedStatPlug: socketRecognizedStatPlug,
+      hasRecognizedMasterworkPlug: socketRecognizedMasterwork,
+      details: socketAdjustmentDetails
+    } : null;
 
     const gearTier = Number(instance?.gearTier);
     if(Number.isFinite(gearTier)){
@@ -2665,7 +2764,7 @@
           energySource: tierEnergySource
         },
         stats: statDebug,
-        sockets: []
+        sockets: socketDebugSummary
       };
       recordArmorDebugSample(sample);
       logDebug('armor row sample', sample);


### PR DESCRIPTION
## Summary
- pass socket data into `buildRowFromDefinition` so stat computation can account for plug deltas
- subtract plug and masterwork adjustments from current stats when base values are missing and normalize the result
- capture socket subtraction details in the debug payload for continued transparency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d18e46a7c0832d9ad0816fc060a269