### PR TITLE
Fix Bungie OAuth flow for DIM sync

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -64,6 +64,8 @@
       </div>
     </header>
 
+    <div id="dim-status" style="padding:6px 10px;border:1px solid #555;display:inline-block;margin:8px 0;">DIM: Connecting…</div>
+
     <section class="panel panel-auth" id="bungiePanel">
       <div class="auth-header">
         <h2>Connect with Bungie</h2>
@@ -82,20 +84,6 @@
       </div>
       <div class="auth-note muted">Tokens are stored locally in this browser only.</div>
       <div id="bungieStatus" class="auth-status muted" aria-live="polite"></div>
-    </section>
-
-    <section class="panel panel-auth" id="dimPanel">
-      <div class="auth-header">
-        <h2>Connect with DIM Sync</h2>
-        <p class="muted">Sign in with DIM to layer your item tags on top of Bungie or CSV armor loads.</p>
-      </div>
-      <div class="auth-buttons">
-        <button id="dimLogin" type="button" class="btn btn-primary">Sign in with DIM</button>
-        <button id="dimRefresh" type="button" class="btn">Sync DIM tags</button>
-        <button id="dimLogout" type="button" class="btn">Disconnect</button>
-      </div>
-      <div class="auth-note muted">DIM access is configured for this site. Tokens stay local to this browser.</div>
-      <div id="dimStatus" class="auth-status muted" aria-live="polite"></div>
     </section>
 
     <section class="panel panel-debug" id="debugPanel">
@@ -163,6 +151,48 @@
     </section>
   </div>
 
+  <script type="module">
+    import { initAutoDimSync } from './dim-sync.js';
+    const DIM_API_KEY = '6114881e-0a01-43b5-a6de-81014184d2fa';
+    window.__D2AA_DIM_API_KEY__ = DIM_API_KEY;
+    const controller = initAutoDimSync({
+      bungieApiKey: '96e154014bdd44c0a537e482709b7473',
+      clientId: '50794',
+      redirectUri: 'https://erebusares.github.io/D2AA/beta.html',
+      dimApiKey: DIM_API_KEY
+    });
+    window.__d2aaDimSync = controller;
+  </script>
+  <script>
+  (function(){
+    if (!location.search.includes('debug=1')) return;
+    const byName = {};
+    for (const s of document.scripts) {
+      const name = s.src ? s.src.split('/').pop().split('?')[0] : '(inline)';
+      (byName[name] ||= []).push(s);
+    }
+    const dups = Object.entries(byName).filter(([, arr]) => arr.length > 1);
+    if (dups.length) console.warn('[D2AA] Duplicate scripts:', dups.map(([n, arr]) => ({ name: n, count: arr.length, srcs: arr.map((s) => s.src) })));
+  })();
+  </script>
+  <script>
+  (function(){
+    if (!location.search.includes('debug=1')) return;
+    const names = ['computeBaseArmorStats','createManifestClient','CORE_STATS'];
+    for (const n of names) {
+      let v = window[n];
+      Object.defineProperty(window, n, {
+        configurable: true,
+        enumerable: true,
+        get(){ return v; },
+        set(nv){
+          console.warn(`[D2AA tripwire] window.${n} overwritten by`, document.currentScript?.src || '(inline)');
+          v = nv;
+        }
+      });
+    }
+  })();
+  </script>
   <script>
   // ====== Constants ======
   const STAT_COLS = [
@@ -942,7 +972,7 @@
 
   function loadDimTokens(){
     try{
-      const raw = localStorage.getItem(DIM_TOKEN_STORAGE);
+      const raw = sessionStorage.getItem(DIM_TOKEN_STORAGE);
       if(!raw) return null;
       const parsed = JSON.parse(raw);
       if(!parsed?.accessToken) return null;
@@ -961,9 +991,9 @@
   function saveDimTokens(){
     try{
       if(!dimTokens?.accessToken){
-        localStorage.removeItem(DIM_TOKEN_STORAGE);
+        sessionStorage.removeItem(DIM_TOKEN_STORAGE);
       }else{
-        localStorage.setItem(DIM_TOKEN_STORAGE, JSON.stringify(dimTokens));
+        sessionStorage.setItem(DIM_TOKEN_STORAGE, JSON.stringify(dimTokens));
       }
     }catch(err){
       console.warn('Failed to persist DIM tokens', err);
@@ -978,7 +1008,7 @@
 
   function clearDimTokens(showMessage){
     dimTokens = null;
-    localStorage.removeItem(DIM_TOKEN_STORAGE);
+    sessionStorage.removeItem(DIM_TOKEN_STORAGE);
     if(showMessage){
       setDimStatus('DIM session cleared. Tags will sync after the next armor load.', 'info');
     }else{
@@ -1121,68 +1151,22 @@
     if(hasValidDimToken()){
       return dimTokens.accessToken;
     }
-    return requestDimToken();
+    const controller = window.__d2aaDimSync;
+    if(controller && typeof controller.refresh === 'function'){
+      try{
+        await controller.refresh();
+      }catch(err){
+        logDebug('ensureDimAccessToken refreshError', { error: err?.message || err });
+      }
+      if(hasValidDimToken()){
+        return dimTokens.accessToken;
+      }
+    }
+    throw new Error('DIM session is not ready. Reload the page to reconnect.');
   }
 
   async function requestDimToken(){
-    const dimApiKey = getDimApiKey();
-    if(!dimApiKey){
-      throw new Error('DIM API key is not configured.');
-    }
-    const membership = getSelectedMembership();
-    const membershipId = membership?.membershipId || bungieConfig?.membershipId || bungieTokens?.membershipId;
-    if(!membershipId){
-      throw new Error('Select a Bungie profile before connecting to DIM.');
-    }
-    if(dimTokens?.membershipId && String(dimTokens.membershipId) !== String(membershipId)){
-      clearDimTokens(false);
-    }
-    await ensureAccessToken();
-    let response;
-    try{
-      response = await fetch(`${DIM_API_ROOT}/auth/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-API-Key': dimApiKey,
-          'X-DIM-Version': DIM_APP_VERSION
-        },
-        body: JSON.stringify({
-          bungieAccessToken: bungieTokens?.accessToken || '',
-          membershipId: String(membershipId)
-        })
-      });
-    }catch(err){
-      logDebug('dimAuth networkError', { error: err?.message || err });
-      throw new Error(formatDimNetworkError(err));
-    }
-    const data = await response.json().catch(()=>null);
-    if(!response.ok){
-      if(response.status === 401){
-        clearDimTokens(false);
-      }
-      const message = data?.error && data?.message ? `${data.error}: ${data.message}` : `DIM auth failed (HTTP ${response.status})`;
-      throw new Error(message);
-    }
-    if(!data?.accessToken){
-      throw new Error('DIM auth response missing accessToken.');
-    }
-    const expiresInSeconds = Number(data?.expiresInSeconds || 0);
-    const expiresAt = Number.isFinite(expiresInSeconds) && expiresInSeconds > 0
-      ? Date.now() + expiresInSeconds * 1000
-      : 0;
-    dimTokens = {
-      accessToken: data.accessToken,
-      expiresAt,
-      membershipId: String(membershipId)
-    };
-    saveDimTokens();
-    updateDimUI();
-    logDebug('dimAuth success', {
-      membershipId: String(membershipId),
-      expiresInSeconds: Number.isFinite(expiresInSeconds) ? expiresInSeconds : null
-    });
-    return dimTokens.accessToken;
+    return ensureDimAccessToken();
   }
 
   function buildDimRequestHeaders(accessToken){
@@ -1251,65 +1235,21 @@
       logDebug('syncDimProfile skipped', { reason, dimIsFetching: true });
       return false;
     }
-    const dimApiKey = getDimApiKey();
-    if(!dimApiKey){
-      setDimStatus('DIM Sync is not configured for this build.', 'error');
-      return false;
-    }
-    const membership = getSelectedMembership();
-    const membershipId = membership?.membershipId || bungieConfig?.membershipId || bungieTokens?.membershipId;
-    if(!membershipId){
+    const controller = window.__d2aaDimSync;
+    if(!controller || typeof controller.refresh !== 'function'){
       if(!silent){
-        setDimStatus('Select a Bungie profile before syncing DIM tags.', 'error');
+        setDimStatus('DIM Sync is not configured for this build.', 'error');
       }
       return false;
-    }
-    if(dimTokens?.membershipId && String(dimTokens.membershipId) !== String(membershipId)){
-      clearDimTokens(false);
     }
     dimIsFetching = true;
     updateDimUI();
-    const startMessage = reason === 'auto' ? 'Checking DIM Sync…' : 'Syncing DIM tags…';
     if(!silent){
-      setDimStatus(startMessage, 'loading');
+      setDimStatus(reason === 'auto' ? 'Checking DIM Sync…' : 'Syncing DIM tags…', 'loading');
     }
     try{
-      await ensureAccessToken();
-      const params = {
-        components: 'tags,hashtags',
-        platformMembershipId: String(membershipId),
-        destinyVersion: '2'
-      };
-      if(dimSyncToken && !options?.forceFull){
-        params.sync = dimSyncToken;
-      }
-      const response = await dimApiRequest('/profile', { method: 'GET', params });
-      const tags = Array.isArray(response?.tags) ? response.tags : [];
-      const itemHashTags = Array.isArray(response?.itemHashTags) ? response.itemHashTags : [];
-      dimProfile = {
-        tags,
-        itemHashTags,
-        fetchedAt: Date.now(),
-        syncToken: response?.syncToken ?? null
-      };
-      dimSyncToken = dimProfile.syncToken ?? null;
-      dimConfig.lastMembershipId = String(membershipId);
-      saveDimConfig();
-      saveDimProfileCache();
-      const changed = applyDimProfileToRows({ render: false });
-      if(changed){
-        saveRows();
-        render();
-      }else if(!silent){
-        render();
-      }
-      refreshDimStatusFromProfile();
-      logDebug('dimSync success', {
-        reason,
-        tagCount: tags.length,
-        itemHashTagCount: itemHashTags.length,
-        usedSyncToken: Boolean(dimSyncToken && options?.forceFull !== true)
-      });
+      await controller.refresh({ forceAuth: options?.forceFull });
+      logDebug('dimSync success', { reason, usedController: true });
       updateDebugSnapshot();
       return true;
     }catch(err){
@@ -1380,49 +1320,49 @@
   }
 
   function initDimIntegration(){
-    dimStatusEl = document.getElementById('dimStatus');
-    dimLoginBtn = document.getElementById('dimLogin');
-    dimRefreshBtn = document.getElementById('dimRefresh');
-    dimLogoutBtn = document.getElementById('dimLogout');
-
-    if(dimLoginBtn){
-      dimLoginBtn.addEventListener('click', () => {
-        syncDimProfile({ reason: 'manual' });
-      });
-    }
-
-    if(dimRefreshBtn){
-      dimRefreshBtn.addEventListener('click', () => {
-        syncDimProfile({ reason: 'manual' });
-      });
-    }
-
-    if(dimLogoutBtn){
-      dimLogoutBtn.addEventListener('click', () => {
-        clearDimTokens(true);
-      });
-    }
-
-    if(dimProfile && (Array.isArray(dimProfile.tags) || Array.isArray(dimProfile.itemHashTags))){
-      const tagCount = Array.isArray(dimProfile.tags) ? dimProfile.tags.length : 0;
-      const hashTagCount = Array.isArray(dimProfile.itemHashTags) ? dimProfile.itemHashTags.length : 0;
-      if(tagCount || hashTagCount){
-        setDimStatus(`Loaded ${tagCount} DIM tag${tagCount === 1 ? '' : 's'} from last sync.`, 'info');
-      }else if(!getDimApiKey()){
-        setDimStatus('DIM Sync is not configured for this build.', 'info');
-      }else{
-        setDimStatus('Sign in with DIM to sync your tags.', 'info');
+    window.addEventListener('d2aa:dim-profile', (event) => {
+      const detail = event?.detail || {};
+      const profile = detail.profile || {};
+      const tags = Array.isArray(profile.tags) ? profile.tags : [];
+      const itemHashTags = Array.isArray(profile.itemHashTags) ? profile.itemHashTags : [];
+      dimProfile = {
+        tags,
+        itemHashTags,
+        fetchedAt: Date.now(),
+        syncToken: profile?.syncToken ?? null
+      };
+      dimSyncToken = dimProfile.syncToken ?? null;
+      if(detail?.membershipId){
+        dimConfig.lastMembershipId = String(detail.membershipId);
+        saveDimConfig();
       }
-    }else if(!getDimApiKey()){
-      setDimStatus('DIM Sync is not configured for this build.', 'info');
-    }else{
-      setDimStatus('Sign in with DIM to sync your tags.', 'info');
-    }
+      if(detail?.dimAccessToken){
+        dimTokens = {
+          accessToken: detail.dimAccessToken,
+          expiresAt: detail?.dimAccessTokenExpiresAt || 0,
+          membershipId: detail?.membershipId ? String(detail.membershipId) : null
+        };
+      }else{
+        dimTokens = null;
+      }
+      saveDimTokens();
+      saveDimProfileCache();
+      refreshDimStatusFromProfile();
+      const changed = applyDimProfileToRows({ render: false });
+      const hasRows = Array.isArray(STATE.rows) && STATE.rows.length;
+      if(changed){
+        saveRows();
+        if(hasRows){
+          render();
+        }
+      }else if(hasRows){
+        render();
+      }
+      updateDebugSnapshot();
+    });
 
+    refreshDimStatusFromProfile();
     updateDimUI();
-    if(Array.isArray(STATE.rows) && STATE.rows.length){
-      syncDimProfile({ reason: 'auto', silent: true });
-    }
   }
 
   function updateBungieUI(){

--- a/dim-sync.js
+++ b/dim-sync.js
@@ -1,0 +1,443 @@
+const BUNGIE_TOKEN_KEY = 'd2aa:bungieAccessToken';
+const BUNGIE_TOKEN_EXPIRES_KEY = 'd2aa:bungieAccessTokenExpires';
+const BUNGIE_TOKEN_TYPE_KEY = 'd2aa:bungieAccessTokenType';
+const BUNGIE_MEMBERSHIP_KEY = 'd2aa:bungieMembership';
+const DIM_TOKEN_KEY = 'd2aa:dimAccessToken';
+const DIM_TOKEN_EXPIRES_KEY = 'd2aa:dimAccessTokenExpires';
+const DIM_TOKEN_MEMBERSHIP_KEY = 'd2aa:dimMembershipId';
+const STATUS_ELEMENT_ID = 'dim-status';
+const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000;
+
+class RedirectingError extends Error {
+  constructor() {
+    super('Redirecting to Bungie OAuth');
+    this.name = 'RedirectingError';
+    this.isRedirect = true;
+  }
+}
+
+function readSession(key) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function writeSession(key, value) {
+  try {
+    if (value === null || value === undefined) {
+      sessionStorage.removeItem(key);
+    } else {
+      sessionStorage.setItem(key, value);
+    }
+  } catch (_err) {
+    // Ignore storage errors (e.g. private browsing restrictions).
+  }
+}
+
+function readJsonSession(key) {
+  const raw = readSession(key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function writeJsonSession(key, value) {
+  if (value === null || value === undefined) {
+    writeSession(key, null);
+  } else {
+    writeSession(key, JSON.stringify(value));
+  }
+}
+
+function getStatusElement() {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(STATUS_ELEMENT_ID);
+}
+
+function setStatus(text, { clickHandler } = {}) {
+  const el = getStatusElement();
+  if (!el) return;
+
+  el.textContent = text;
+  if (clickHandler) {
+    el.style.cursor = 'pointer';
+    el.onclick = clickHandler;
+  } else {
+    el.style.cursor = '';
+    el.onclick = null;
+  }
+}
+
+function cleanOAuthHash() {
+  if (typeof window === 'undefined') return;
+  try {
+    const url = new URL(window.location.href);
+    url.hash = '';
+    window.history.replaceState({}, document.title, url.toString());
+  } catch (_err) {
+    // ignore URL manipulation failures
+  }
+}
+
+function clearBungieSession() {
+  writeSession(BUNGIE_TOKEN_KEY, null);
+  writeSession(BUNGIE_TOKEN_EXPIRES_KEY, null);
+  writeSession(BUNGIE_TOKEN_TYPE_KEY, null);
+  writeJsonSession(BUNGIE_MEMBERSHIP_KEY, null);
+}
+
+function clearDimSession() {
+  writeSession(DIM_TOKEN_KEY, null);
+  writeSession(DIM_TOKEN_EXPIRES_KEY, null);
+  writeSession(DIM_TOKEN_MEMBERSHIP_KEY, null);
+}
+
+function clearAllSessions() {
+  clearBungieSession();
+  clearDimSession();
+}
+
+function captureBungieTokenFromHash() {
+  if (typeof window === 'undefined') return null;
+
+  const hash = window.location.hash;
+  if (!hash || hash.length <= 1) return null;
+
+  const params = new URLSearchParams(hash.slice(1));
+
+  if (params.has('error')) {
+    const error = params.get('error');
+    const description = params.get('error_description') || params.get('errorDescription');
+    cleanOAuthHash();
+    throw new Error(`Bungie OAuth error: ${error}${description ? ` - ${description}` : ''}`);
+  }
+
+  const token = params.get('access_token');
+  if (!token) {
+    return null;
+  }
+
+  const tokenType = params.get('token_type') || params.get('tokenType') || 'Bearer';
+  const expiresRaw = params.get('expires_in') || params.get('expiresIn');
+  const expiresInSeconds = Number(expiresRaw);
+  const lifetime = Number.isFinite(expiresInSeconds) && expiresInSeconds > 0 ? expiresInSeconds : 3600;
+  const expiresAt = Date.now() + lifetime * 1000;
+
+  writeSession(BUNGIE_TOKEN_KEY, token);
+  writeSession(BUNGIE_TOKEN_EXPIRES_KEY, String(expiresAt));
+  writeSession(BUNGIE_TOKEN_TYPE_KEY, tokenType);
+  writeJsonSession(BUNGIE_MEMBERSHIP_KEY, null);
+  clearDimSession();
+  cleanOAuthHash();
+
+  return { accessToken: token, tokenType, expiresAt };
+}
+
+function getStoredBungieToken() {
+  const token = readSession(BUNGIE_TOKEN_KEY);
+  if (!token) return null;
+  const expiresRaw = readSession(BUNGIE_TOKEN_EXPIRES_KEY);
+  const expiresAt = expiresRaw ? Number(expiresRaw) : 0;
+  if (!expiresAt || Date.now() + TOKEN_EXPIRY_BUFFER_MS >= expiresAt) {
+    clearBungieSession();
+    return null;
+  }
+  const tokenType = readSession(BUNGIE_TOKEN_TYPE_KEY) || 'Bearer';
+  return { accessToken: token, tokenType, expiresAt };
+}
+
+function redirectToBungieAuth({ clientId, redirectUri }) {
+  if (typeof window === 'undefined') {
+    throw new Error('Bungie OAuth requires a browser environment.');
+  }
+
+  const authUrl = new URL('https://www.bungie.net/en/OAuth/Authorize');
+  authUrl.searchParams.set('response_type', 'token');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+
+  setStatus('DIM: Redirecting to Bungie…');
+  window.location.assign(authUrl.toString());
+  throw new RedirectingError();
+}
+
+function ensureBungieToken({ clientId, redirectUri }) {
+  const captured = captureBungieTokenFromHash();
+  if (captured) {
+    return captured;
+  }
+
+  const stored = getStoredBungieToken();
+  if (stored) {
+    return stored;
+  }
+
+  redirectToBungieAuth({ clientId, redirectUri });
+  return null;
+}
+
+function getStoredDimToken({ membershipId }) {
+  const token = readSession(DIM_TOKEN_KEY);
+  if (!token) return null;
+
+  const storedMembership = readSession(DIM_TOKEN_MEMBERSHIP_KEY);
+  if (!storedMembership || String(storedMembership) !== String(membershipId)) {
+    clearDimSession();
+    return null;
+  }
+
+  const expiresRaw = readSession(DIM_TOKEN_EXPIRES_KEY);
+  const expiresAt = expiresRaw ? Number(expiresRaw) : 0;
+  if (!expiresAt || Date.now() + TOKEN_EXPIRY_BUFFER_MS >= expiresAt) {
+    clearDimSession();
+    return null;
+  }
+
+  return { accessToken: token, expiresAt };
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    const error = new Error(`Request failed (${response.status})`);
+    error.status = response.status;
+    error.body = body;
+    throw error;
+  }
+  return response.json();
+}
+
+async function fetchMembershipId({ bungieApiKey }) {
+  const cached = readJsonSession(BUNGIE_MEMBERSHIP_KEY);
+  if (cached?.membershipId && cached?.expiresAt && cached.expiresAt > Date.now()) {
+    return cached;
+  }
+
+  const token = getStoredBungieToken();
+  if (!token) {
+    throw new Error('Missing Bungie access token');
+  }
+
+  const url = 'https://www.bungie.net/Platform/User/GetMembershipsForCurrentUser/';
+  const data = await fetchJson(url, {
+    headers: {
+      'X-API-Key': bungieApiKey,
+      Authorization: `${token.tokenType} ${token.accessToken}`,
+    },
+  });
+
+  const memberships = data?.Response?.destinyMemberships || [];
+  const primary = data?.Response?.primaryMembershipId;
+  let membershipId = null;
+  let membershipType = null;
+
+  if (primary) {
+    const match = memberships.find((entry) => String(entry.membershipId) === String(primary));
+    if (match) {
+      membershipId = String(match.membershipId);
+      membershipType = match.membershipType;
+    }
+  }
+
+  if (!membershipId && memberships.length) {
+    membershipId = String(memberships[0].membershipId);
+    membershipType = memberships[0].membershipType;
+  }
+
+  if (!membershipId) {
+    throw new Error('No Bungie memberships available for this account');
+  }
+
+  const payload = {
+    membershipId,
+    membershipType: membershipType ?? null,
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  };
+  writeJsonSession(BUNGIE_MEMBERSHIP_KEY, payload);
+  return payload;
+}
+
+async function ensureDimToken({ dimApiKey, membershipId }) {
+  const cached = getStoredDimToken({ membershipId });
+  if (cached) {
+    return cached;
+  }
+
+  const bungieToken = getStoredBungieToken();
+  if (!bungieToken) {
+    throw new Error('Missing Bungie access token for DIM exchange');
+  }
+
+  const body = {
+    bungieAccessToken: bungieToken.accessToken,
+    membershipId,
+  };
+
+  const data = await fetchJson('https://api.destinyitemmanager.com/auth/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': dimApiKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const accessToken = data?.accessToken || data?.access_token;
+  const expiresRaw = data?.expiresInSeconds ?? data?.expiresIn ?? data?.expires_in;
+  const expiresInSeconds = Number(expiresRaw);
+  if (!accessToken || !Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+    throw new Error('DIM token exchange returned an invalid response');
+  }
+
+  const expiresAt = Date.now() + expiresInSeconds * 1000;
+  writeSession(DIM_TOKEN_KEY, accessToken);
+  writeSession(DIM_TOKEN_EXPIRES_KEY, String(expiresAt));
+  writeSession(DIM_TOKEN_MEMBERSHIP_KEY, String(membershipId));
+  return { accessToken, expiresAt };
+}
+
+async function fetchDimProfile({ dimApiKey, dimToken, membershipId }) {
+  const url = new URL('https://api.destinyitemmanager.com/profile');
+  url.searchParams.set('platformMembershipId', membershipId);
+  url.searchParams.set('components', 'tags,loadouts,settings');
+
+  return fetchJson(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${dimToken}`,
+      'X-API-Key': dimApiKey,
+    },
+  });
+}
+
+function dispatchProfileEvent(detail) {
+  if (typeof window === 'undefined') return;
+  try {
+    const event = new CustomEvent('d2aa:dim-profile', { detail });
+    window.dispatchEvent(event);
+  } catch (_err) {
+    // ignore environments without CustomEvent support
+  }
+}
+
+function handleError(err) {
+  if (err instanceof RedirectingError && err.isRedirect) {
+    return;
+  }
+
+  console.error('[D2AA][dim-sync] Failed to connect to DIM', err);
+  setStatus('DIM: Error (click to retry)', {
+    clickHandler: () => {
+      clearAllSessions();
+      setStatus('DIM: Connecting…');
+      window.location.reload();
+    },
+  });
+}
+
+async function runSync(config) {
+  const bungieToken = ensureBungieToken(config);
+  if (!bungieToken) {
+    return null;
+  }
+
+  setStatus('DIM: Fetching Bungie profile…');
+
+  let membership;
+  try {
+    membership = await fetchMembershipId({ bungieApiKey: config.bungieApiKey });
+  } catch (err) {
+    if (err?.status === 401) {
+      clearBungieSession();
+      redirectToBungieAuth(config);
+      return null;
+    }
+    throw err;
+  }
+
+  setStatus('DIM: Connecting to DIM…');
+
+  let dimToken;
+  try {
+    dimToken = await ensureDimToken({
+      dimApiKey: config.dimApiKey,
+      membershipId: membership.membershipId,
+    });
+  } catch (err) {
+    if (err?.status === 401) {
+      clearDimSession();
+      clearBungieSession();
+      redirectToBungieAuth(config);
+      return null;
+    }
+    throw err;
+  }
+
+  setStatus('DIM: Syncing DIM profile…');
+
+  const profile = await fetchDimProfile({
+    dimApiKey: config.dimApiKey,
+    dimToken: dimToken.accessToken,
+    membershipId: membership.membershipId,
+  });
+
+  const tags = Array.isArray(profile?.tags) ? profile.tags : [];
+  const itemHashTags = Array.isArray(profile?.itemHashTags) ? profile.itemHashTags : [];
+  const loadouts = Array.isArray(profile?.loadouts) ? profile.loadouts : [];
+
+  setStatus(`DIM: Connected ✓  Loadouts: ${loadouts.length} | Tagged: ${tags.length + itemHashTags.length}`);
+
+  dispatchProfileEvent({
+    profile,
+    membershipId: membership.membershipId,
+    membershipType: membership.membershipType ?? null,
+    bungieAccessToken: bungieToken.accessToken,
+    bungieAccessTokenExpiresAt: bungieToken.expiresAt,
+    dimAccessToken: dimToken.accessToken,
+    dimAccessTokenExpiresAt: dimToken.expiresAt,
+  });
+
+  return profile;
+}
+
+export function initAutoDimSync({ bungieApiKey, clientId, redirectUri, dimApiKey }) {
+  if (typeof window === 'undefined') {
+    return {
+      refresh: async () => null,
+    };
+  }
+
+  if (!bungieApiKey || !clientId || !redirectUri || !dimApiKey) {
+    throw new Error('initAutoDimSync requires Bungie and DIM credentials');
+  }
+
+  const config = { bungieApiKey, clientId, redirectUri, dimApiKey };
+  setStatus('DIM: Connecting…');
+
+  runSync(config).catch(handleError);
+
+  return {
+    refresh: async (options = {}) => {
+      try {
+        if (options.forceAuth) {
+          clearAllSessions();
+        } else {
+          clearDimSession();
+        }
+        return await runSync(config);
+      } catch (err) {
+        if (err instanceof RedirectingError && err.isRedirect) {
+          return null;
+        }
+        handleError(err);
+        return null;
+      }
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary
- restore the implicit grant Bungie OAuth flow by capturing access tokens from the URL hash and redirecting with response_type=token
- cache Bungie, DIM, and membership details in sessionStorage with expiry-aware refresh handling while dispatching the existing profile event
- streamline DIM status updates and error handling so failed attempts clear storage and offer a click-to-retry flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19a384538832da9dc235c9cbb83b6