### PR TITLE
Add Bungie sign-in flow and emphasize base stat comparisons

### DIFF
--- a/beta-docs/README.md
+++ b/beta-docs/README.md
@@ -4,7 +4,7 @@ This beta build fetches real-time Destiny 2 armor directly from Bungie.net witho
 
 ## OAuth flow
 
-* **Grant type:** [Implicit Grant Flow](https://bungie-net.github.io/#Implicit-Grant-Flow). The page redirects the user to Bungie, and Bungie returns to `https://erebusares.github.io/D2AA/beta.html` with an access token in the URL hash.
+* **Grant type:** [Implicit Grant Flow](https://bungie-net.github.io/#Implicit-Grant-Flow). Users click “Sign in with Bungie” to start the redirect, and Bungie returns to `https://erebusares.github.io/D2AA/beta.html` with an access token in the URL hash.
 * **Storage:** The token is saved in `sessionStorage` under the key `bungie_access_token`. The hash is immediately stripped from the URL via `history.replaceState`.
 * **Expiry:** If Bungie provides `expires_in`, an absolute expiry timestamp is stored. When the token is expired the module clears it and triggers a fresh OAuth redirect.
 * **Membership lookup:** After OAuth completes we call `/User/GetMembershipsForCurrentUser/` and use the first `destinyMemberships` entry. The membership ID and type are cached in the in-memory app state.

--- a/beta-docs/auth-bungie.js
+++ b/beta-docs/auth-bungie.js
@@ -61,6 +61,7 @@ function readStoredToken() {
 }
 
 function ensureTokenFromRedirect() {
+  if (typeof window === 'undefined') return null;
   const parsed = parseTokenFromHash(window.location.hash);
   if (!parsed) return null;
   storeToken(parsed);
@@ -79,13 +80,19 @@ function redirectToOAuth({ clientId, redirectUri }) {
   window.location.assign(url.toString());
 }
 
-export function getBungieAccessToken({ clientId, redirectUri }) {
-  const existing = ensureTokenFromRedirect() || readStoredToken();
-  if (existing) {
-    return existing;
-  }
+export function getStoredBungieAccessToken() {
+  return ensureTokenFromRedirect() || readStoredToken();
+}
+
+export function clearStoredBungieAccessToken() {
+  const storage = getSessionStorage();
+  if (!storage) return;
+  storage.removeItem(TOKEN_STORAGE_KEY);
+  storage.removeItem(TOKEN_EXPIRY_KEY);
+}
+
+export function beginBungieOAuth({ clientId, redirectUri }) {
   redirectToOAuth({ clientId, redirectUri });
-  return null;
 }
 
 async function fetchJson(url, { headers }) {

--- a/beta-docs/boot.js
+++ b/beta-docs/boot.js
@@ -1,4 +1,9 @@
-import { getBungieAccessToken, getMembershipId } from './auth-bungie.js';
+import {
+  beginBungieOAuth,
+  clearStoredBungieAccessToken,
+  getStoredBungieAccessToken,
+  getMembershipId,
+} from './auth-bungie.js';
 import { getProfile } from './bungie-client.js';
 import { createManifestClient } from './manifest.js';
 import {
@@ -8,6 +13,7 @@ import {
 } from './items-adapter.js';
 import { renderTable } from './ui-render.js';
 import { createState } from './state.js';
+import { createElement } from './utils.js';
 
 const BUNGIE_API_KEY = '96e154014bdd44c0a537e482709b7473';
 const CLIENT_ID = '50794';
@@ -15,14 +21,157 @@ const REDIRECT_URI = 'https://erebusares.github.io/D2AA/beta.html';
 
 const state = createState();
 
-async function boot() {
-  const mount = document.getElementById('app');
-  try {
-    const token = getBungieAccessToken({
-      clientId: CLIENT_ID,
-      redirectUri: REDIRECT_URI,
+const mount = document.getElementById('app');
+let tableController = null;
+
+function resetState() {
+  state.setState({
+    accessToken: null,
+    membershipId: null,
+    membershipType: null,
+    characters: [],
+    selectedCharacterId: null,
+  });
+}
+
+function renderCard(children, { className } = {}) {
+  if (!mount) return;
+  mount.innerHTML = '';
+  const card = createElement('div', {
+    className: ['beta-card', className].filter(Boolean).join(' '),
+    children,
+  });
+  mount.appendChild(card);
+}
+
+function renderSignIn({ status, tone = 'info' } = {}) {
+  const children = [];
+  children.push(
+    createElement('h2', {
+      className: 'beta-card__title',
+      textContent: 'Sign in to Bungie.net',
+    })
+  );
+  children.push(
+    createElement('p', {
+      className: 'beta-card__text',
+      textContent:
+        'Connect to load your live Destiny 2 armor with base stat comparisons just like the CSV analyzer.',
+    })
+  );
+  if (status) {
+    const statusClasses = ['beta-card__status'];
+    if (tone === 'error') {
+      statusClasses.push('beta-card__status--error');
+    }
+    children.push(
+      createElement('div', {
+        className: statusClasses.join(' '),
+        textContent: status,
+      })
+    );
+  }
+
+  const button = createElement('button', {
+    className: 'beta-button',
+    textContent: 'Sign in with Bungie',
+  });
+  button.addEventListener('click', () => {
+    renderLoading('Redirecting to Bungie…');
+    beginBungieOAuth({ clientId: CLIENT_ID, redirectUri: REDIRECT_URI });
+  });
+  children.push(button);
+  children.push(
+    createElement('p', {
+      className: 'beta-card__hint',
+      textContent: 'You\'ll be redirected to Bungie.net and back once authorization succeeds.',
+    })
+  );
+
+  renderCard(children, { className: 'beta-card--centered' });
+}
+
+function renderLoading(message = 'Loading your armor…') {
+  renderCard(
+    [
+      createElement('p', {
+        className: 'beta-card__text',
+        textContent: message,
+      }),
+    ],
+    { className: 'beta-card--centered' }
+  );
+}
+
+function renderError(message) {
+  const retryButton = createElement('button', {
+    className: 'beta-button',
+    textContent: 'Try again',
+  });
+  retryButton.addEventListener('click', () => {
+    boot();
+  });
+
+  const signInButton = createElement('button', {
+    className: 'beta-button beta-button--ghost',
+    textContent: 'Sign in again',
+  });
+  signInButton.addEventListener('click', () => {
+    handleSignOut({ showMessage: false });
+  });
+
+  renderCard(
+    [
+      createElement('h2', {
+        className: 'beta-card__title',
+        textContent: 'Unable to load armor',
+      }),
+      createElement('div', {
+        className: 'beta-card__status beta-card__status--error',
+        textContent: message,
+      }),
+      createElement('div', {
+        className: 'beta-card__actions',
+        children: [retryButton, signInButton],
+      }),
+    ],
+    { className: 'beta-card--centered' }
+  );
+}
+
+function handleSignOut({ showMessage, status, statusTone } = {}) {
+  if (tableController && typeof tableController.destroy === 'function') {
+    tableController.destroy();
+  }
+  tableController = null;
+  clearStoredBungieAccessToken();
+  resetState();
+  if (typeof status === 'string' && status.trim().length) {
+    renderSignIn({ status, tone: statusTone });
+  } else if (showMessage) {
+    renderSignIn({
+      status: 'You have signed out. Sign in again to reload your armor.',
+      tone: 'info',
     });
-    if (!token) return; // Redirecting for OAuth
+  } else {
+    renderSignIn();
+  }
+}
+
+async function boot() {
+  if (!mount) return;
+  if (tableController && typeof tableController.destroy === 'function') {
+    tableController.destroy();
+    tableController = null;
+  }
+  try {
+    const token = getStoredBungieAccessToken();
+    if (!token) {
+      handleSignOut({ showMessage: false });
+      return;
+    }
+
+    renderLoading();
     state.setState({ accessToken: token });
 
     const { membershipId, membershipType } = await getMembershipId(BUNGIE_API_KEY, token);
@@ -54,16 +203,25 @@ async function boot() {
       selectedCharacterId: defaultCharacterId,
     });
 
-    renderTable(mount, rows, { state });
+    if (tableController && typeof tableController.destroy === 'function') {
+      tableController.destroy();
+    }
+    tableController = renderTable(mount, rows, {
+      state,
+      onSignOut: () => handleSignOut({ showMessage: true }),
+    });
   } catch (error) {
     console.error('[D2AA][beta] Failed to boot application', error);
-    if (mount) {
-      mount.innerHTML = '';
-      const message = document.createElement('div');
-      message.className = 'beta-error';
-      message.textContent = error.message || 'Something went wrong while loading armor.';
-      mount.appendChild(message);
+    const message = error?.message || 'Something went wrong while loading armor.';
+    const lower = message.toLowerCase();
+    if (lower.includes('401') || lower.includes('unauthorized') || lower.includes('access token')) {
+      handleSignOut({
+        status: 'Your Bungie session expired. Sign in again to continue.',
+        statusTone: 'error',
+      });
+      return;
     }
+    renderError(message);
   }
 }
 

--- a/beta-docs/ui-render.js
+++ b/beta-docs/ui-render.js
@@ -124,7 +124,7 @@ function buildEmptyRow(colspan) {
   return row;
 }
 
-export function renderTable(container, initialRows, { state } = {}) {
+export function renderTable(container, initialRows, { state, onSignOut } = {}) {
   if (!container) return null;
   let rows = Array.isArray(initialRows) ? [...initialRows] : [];
   const root = createElement('div', { className: 'beta-layout' });
@@ -142,6 +142,15 @@ export function renderTable(container, initialRows, { state } = {}) {
     textContent: 'Current',
   });
   controls.append(label, toggleBase, toggleCurrent);
+
+  if (typeof onSignOut === 'function') {
+    const signOut = createElement('button', {
+      className: 'beta-signout',
+      textContent: 'Sign out',
+    });
+    signOut.addEventListener('click', () => onSignOut());
+    controls.append(signOut);
+  }
 
   const table = createElement('table', { className: 'armor-table' });
   const thead = buildTableHead();
@@ -194,8 +203,9 @@ export function renderTable(container, initialRows, { state } = {}) {
   toggleBase.addEventListener('click', () => setStatView('base'));
   toggleCurrent.addEventListener('click', () => setStatView('current'));
 
+  let unsubscribe = null;
   if (state) {
-    state.subscribe((nextState) => {
+    unsubscribe = state.subscribe((nextState) => {
       const nextView = nextState?.statView ?? 'base';
       if (nextView !== statView) {
         statView = nextView;
@@ -212,6 +222,12 @@ export function renderTable(container, initialRows, { state } = {}) {
     update(newRows) {
       rows = Array.isArray(newRows) ? [...newRows] : [];
       renderRows();
+    },
+    destroy() {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+        unsubscribe = null;
+      }
     },
   };
 }

--- a/beta.html
+++ b/beta.html
@@ -10,7 +10,7 @@
   <main class="beta-main">
     <header class="beta-header">
       <h1>D2 Armor Analyzer — Beta</h1>
-      <p>Sign in with Bungie to pull your live Destiny 2 armor and compare Base vs Current stats.</p>
+      <p>Sign in with Bungie to pull your live Destiny 2 armor and focus on base stat comparisons (toggle current values anytime).</p>
     </header>
     <section id="app" class="beta-app">Loading armor…</section>
   </main>

--- a/styles-beta.css
+++ b/styles-beta.css
@@ -68,7 +68,8 @@ body {
   position: relative;
 }
 
-.beta-layout {
+.beta-layout,
+.beta-card {
   background: var(--panel);
   border: 1px solid var(--panel-border);
   border-radius: 20px;
@@ -76,9 +77,109 @@ body {
   box-shadow: 0 32px 78px -40px rgba(124, 215, 255, 0.55);
 }
 
+.beta-card--centered {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.beta-card__title {
+  margin: 0;
+  font-family: 'Rajdhani', 'Inter', sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.beta-card__text {
+  margin: 0;
+  color: var(--text);
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  line-height: 1.5;
+}
+
+.beta-card__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  line-height: 1.4;
+}
+
+.beta-card__status {
+  width: 100%;
+  max-width: 420px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(124, 215, 255, 0.16);
+  background: rgba(124, 215, 255, 0.08);
+  color: var(--text);
+  font-size: 14px;
+  letter-spacing: 0.03em;
+  line-height: 1.5;
+}
+
+.beta-card__status--error {
+  border-color: rgba(205, 88, 88, 0.35);
+  background: rgba(205, 88, 88, 0.12);
+  color: #ff9f9f;
+}
+
+.beta-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+
+.beta-button {
+  padding: 10px 26px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 215, 255, 0.4);
+  background: linear-gradient(135deg, rgba(124, 215, 255, 0.42), rgba(159, 133, 255, 0.52));
+  color: #04070f;
+  font-family: 'Inter', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.beta-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px -14px rgba(124, 215, 255, 0.6);
+  background: linear-gradient(135deg, rgba(124, 215, 255, 0.52), rgba(159, 133, 255, 0.6));
+}
+
+.beta-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.beta-button--ghost {
+  background: transparent;
+  color: var(--muted);
+  border-color: rgba(124, 215, 255, 0.28);
+  box-shadow: none;
+}
+
+.beta-button--ghost:hover {
+  color: var(--text);
+  background: rgba(124, 215, 255, 0.12);
+  border-color: rgba(124, 215, 255, 0.5);
+}
+
 .beta-controls {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   margin-bottom: 18px;
 }
@@ -111,6 +212,27 @@ body {
   border-color: rgba(124, 215, 255, 0.6);
   color: #04070f;
   font-weight: 600;
+}
+
+.beta-signout {
+  margin-left: auto;
+  padding: 6px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 215, 255, 0.28);
+  background: transparent;
+  color: var(--muted);
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.beta-signout:hover {
+  background: rgba(124, 215, 255, 0.16);
+  border-color: rgba(124, 215, 255, 0.5);
+  color: var(--text);
 }
 
 .armor-table {


### PR DESCRIPTION
## Summary
- add a manual Bungie sign-in prompt with improved session handling in the beta boot flow
- expose helpers for retrieving and clearing stored OAuth tokens instead of auto-redirecting
- refresh the beta UI to highlight base-stat comparisons and provide sign-out/error affordances

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1b64b5988832da4a50e3c3c5466c1