### PR TITLE
Configure DIM API key for production host

### DIFF
--- a/beta-docs/README.md
+++ b/beta-docs/README.md
@@ -36,6 +36,12 @@ Bungie OAuth login, on-demand inventory pulls, and DIM Sync for tags.
 
 ## OAuth & DIM Sync
 
+> **Production DIM API Registration:** The public deployment at
+> `https://erebusares.github.io/D2AA/beta.html` is registered with the DIM API
+> using the key `0787f112-823b-4864-95bd-8c4caab2a55b`. If the origin or
+> hostname changes, provision a new key for the updated origin and replace the
+> value in `config.js`.
+
 1. **Bungie Login** – `ensureBungieLogin` stores the access token in
    `sessionStorage` and refreshes when required. `getMembership` resolves the
    primary Destiny membership used for all subsequent calls.

--- a/beta-docs/config.js
+++ b/beta-docs/config.js
@@ -6,7 +6,7 @@ export const CONFIG = {
     authorizeUrl: 'https://www.bungie.net/en/OAuth/Authorize'
   },
   dim: {
-    apiKey: '',
+    apiKey: '0787f112-823b-4864-95bd-8c4caab2a55b',
     apiBase: 'https://api.destinyitemmanager.com'
   }
 };


### PR DESCRIPTION
## Summary
- populate the DIM API key in beta-docs/config.js with the production credential
- document the erebusares.github.io deployment pairing and key in the beta README

## Testing
- node --input-type=module <<'NODE'
import { initDimSync, appDim } from './beta-docs/dim-sync.js';
const calls = [];
// stub fetch to capture request and return success
global.fetch = async (url, options) => {
  calls.push({ url, options });
  return {
    ok: true,
    json: async () => ({ accessToken: 'dim-access-token' })
  };
};
const state = await initDimSync({
  apiKey: 'test-api-key',
  apiBase: 'https://api.example.com',
  accessToken: 'bungie-token',
  membershipId: '1234'
});
console.log('state', state);
console.log('calls', calls);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d2d759d230832db0f18d3a16c28d6a