### PR TITLE
Refactor beta analyzer into modular app with Bungie sign-in

### DIFF
--- a/beta-docs/README.md
+++ b/beta-docs/README.md
@@ -1,0 +1,36 @@
+# Beta Docs Modules
+
+This directory houses the modular rewrite for the beta Destiny 2 Armor Analyzer proof of concept. The modules separate responsibilities around configuration, state management, Bungie OAuth/profile loading, DIM synchronization, stat math, CSV ingestion, and UI rendering.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.js` | Declares configurable constants (API keys, OAuth scopes, storage keys) and helpers for building Bungie/DIM request headers. |
+| `state.js` | Provides a lightweight state container plus helpers for persisting rows and OAuth tokens. |
+| `utils.js` | Generic helpers used across modules (numeric coercion, JSON safety, clipboard, token expiry math). |
+| `auth-bungie.js` | Implements the Bungie OAuth PKCE-lite flow for the front-end, persisting tokens in `sessionStorage` and handling refresh. |
+| `bungie-client.js` | Fetches Bungie profile/character/inventory data for the signed in player. |
+| `manifest.js` | Loads and caches the Destiny manifest components required for armor identification/stat math. |
+| `armor-stats.js` | Normalizes stat math for both CSV rows and live profile items. |
+| `items-adapter.js` | Converts CSV rows or Bungie API items into a unified row shape used by the renderer. |
+| `csv-adapter.js` | Wraps PapaParse for CSV ingestion and data cleaning. |
+| `dim-sync.js` | Handles DIM API token lifecycle and tag/notes synchronization (best-effort). |
+| `ui-render.js` | Builds and updates the DOM, including filters, theme toggle, stat view toggle, and table rendering. |
+
+## Usage
+
+Before loading `beta.html`, set `window.D2AA_CONFIG` with the Bungie API key and client id:
+
+```html
+<script>
+  window.D2AA_CONFIG = {
+    bungieApiKey: 'your-api-key',
+    bungieClientId: '12345',
+    bungieRedirectUri: 'https://your.domain/beta.html',
+    dimBaseUrl: 'https://app.destinyitemmanager.com',
+  };
+</script>
+```
+
+The entry module in `beta.html` reads these values, performs the OAuth hand-off when the "Sign in with Bungie" button is pressed, and hydrates the table with either live profile armor or a fallback CSV upload.

--- a/beta-docs/armor-stats.js
+++ b/beta-docs/armor-stats.js
@@ -1,0 +1,64 @@
+import { STAT_MAP } from './config.js';
+import { guardArray, guardObject, num, statTotals } from './utils.js';
+
+export function computeArmorStatsFromItem(item, manifest) {
+  const statsComponent = guardObject(item?.stats ?? item?.statsComponent);
+  const dataStats = statsComponent?.data?.stats ?? statsComponent?.stats ?? statsComponent;
+  const base = {};
+  const current = {};
+
+  for (const stat of Object.values(dataStats ?? {})) {
+    const statHash = Number(stat.statHash ?? stat.stat_id ?? stat.statId);
+    const configEntry = STAT_MAP.find((entry) => entry.id === statHash);
+    if (!configEntry) continue;
+    const baseValue = num(stat?.investmentValue ?? stat?.base ?? stat?.baseValue ?? stat?.value ?? 0);
+    const totalValue = num(stat?.value ?? stat?.actual ?? baseValue);
+    base[statHash] = baseValue;
+    current[statHash] = totalValue;
+  }
+
+  return {
+    base,
+    current,
+    totalBase: statTotals(base),
+    totalCurrent: statTotals(current),
+  };
+}
+
+export function computeArmorStatsFromCsv(row) {
+  const base = {};
+  const current = {};
+  for (const stat of STAT_MAP) {
+    const baseKey = `${stat.label} (Base)`;
+    const totalKey = `${stat.label} (Total)`;
+    base[stat.id] = num(row[`${stat.label} (Base)`] ?? row[stat.label] ?? row[stat.short] ?? 0);
+    const total = row[totalKey] ?? row[`${stat.label} (Current)`];
+    current[stat.id] = num(total, base[stat.id]);
+  }
+  return {
+    base,
+    current,
+    totalBase: statTotals(base),
+    totalCurrent: statTotals(current),
+  };
+}
+
+export function buildDisplayStatList(stats, view = 'BASE') {
+  const source = view === 'CURRENT' ? stats.current : stats.base;
+  return STAT_MAP.map((entry) => source?.[entry.id] ?? 0);
+}
+
+export function formatStatTooltip(stats) {
+  return STAT_MAP.map((entry) => {
+    const baseValue = stats.base?.[entry.id] ?? 0;
+    const currentValue = stats.current?.[entry.id] ?? baseValue;
+    const delta = currentValue - baseValue;
+    const deltaText = delta ? ` (${delta >= 0 ? '+' : ''}${delta})` : '';
+    return `${entry.label}: ${currentValue}${deltaText}`;
+  }).join('\n');
+}
+
+export function isArmorItem(definition) {
+  if (!definition) return false;
+  return definition.itemType === 2 || definition.itemCategoryHashes?.includes(20);
+}

--- a/beta-docs/auth-bungie.js
+++ b/beta-docs/auth-bungie.js
@@ -1,0 +1,192 @@
+import {
+  BUNGIE_CLIENT_ID,
+  BUNGIE_REDIRECT_URI,
+  BUNGIE_SCOPES,
+  BUNGIE_PLATFORM_URL,
+  STORAGE_KEYS,
+} from './config.js';
+import {
+  buildExpiresAt,
+  clearSearchParam,
+  invariant,
+  isTokenExpired,
+  readSearchParam,
+  safeJsonStringify,
+} from './utils.js';
+import {
+  persistBungieTokens,
+  restoreBungieTokens,
+  clearBungieTokens,
+  updateBungieState,
+} from './state.js';
+
+function randomString(length = 32) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  const randomValues = crypto.getRandomValues(new Uint8Array(length));
+  randomValues.forEach((value) => {
+    result += chars[value % chars.length];
+  });
+  return result;
+}
+
+export class BungieAuth {
+  constructor(store) {
+    invariant(store, 'BungieAuth requires a StateStore instance');
+    this.store = store;
+    this.tokens = restoreBungieTokens();
+    if (this.tokens) {
+      updateBungieState(store, {
+        tokens: this.tokens,
+        status: 'ready',
+        membershipId: this.tokens.membership_id ?? this.tokens.membershipId ?? null,
+      });
+    }
+  }
+
+  buildAuthorizeUrl() {
+    const state = randomString(24);
+    try {
+      sessionStorage.setItem(STORAGE_KEYS.bungieOAuthState, state);
+    } catch (error) {
+      console.warn('Unable to store oauth state', error);
+    }
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: BUNGIE_CLIENT_ID,
+      state,
+      redirect_uri: BUNGIE_REDIRECT_URI,
+    });
+    if (Array.isArray(BUNGIE_SCOPES) && BUNGIE_SCOPES.length) {
+      params.set('scope', BUNGIE_SCOPES.join(' '));
+    }
+    return `https://www.bungie.net/en/OAuth/Authorize?${params.toString()}`;
+  }
+
+  startLogin() {
+    const url = this.buildAuthorizeUrl();
+    window.location.assign(url);
+  }
+
+  async handleRedirect() {
+    const code = readSearchParam('code');
+    const state = readSearchParam('state');
+    if (!code) return null;
+    const storedState = sessionStorage.getItem(STORAGE_KEYS.bungieOAuthState);
+    if (storedState && state !== storedState) {
+      throw new Error('OAuth state mismatch');
+    }
+    try {
+      sessionStorage.removeItem(STORAGE_KEYS.bungieOAuthState);
+    } catch (_) {}
+    clearSearchParam('code');
+    clearSearchParam('state');
+    const token = await this.exchangeCode(code);
+    this.setTokens(token);
+    return token;
+  }
+
+  async exchangeCode(code) {
+    const body = new URLSearchParams({
+      client_id: BUNGIE_CLIENT_ID,
+      grant_type: 'authorization_code',
+      code,
+    });
+    const res = await fetch(`${BUNGIE_PLATFORM_URL}/App/OAuth/Token/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Bungie token exchange failed: ${res.status} ${text}`);
+    }
+    const json = await res.json();
+    const normalized = this.normalizeTokenResponse(json);
+    persistBungieTokens(normalized);
+    return normalized;
+  }
+
+  async refreshToken() {
+    if (!this.tokens?.refresh_token) {
+      throw new Error('No refresh token available');
+    }
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: this.tokens.refresh_token,
+      client_id: BUNGIE_CLIENT_ID,
+    });
+    const res = await fetch(`${BUNGIE_PLATFORM_URL}/App/OAuth/Token/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Bungie token refresh failed: ${res.status} ${text}`);
+    }
+    const json = await res.json();
+    const normalized = this.normalizeTokenResponse(json);
+    this.setTokens(normalized);
+    return normalized;
+  }
+
+  normalizeTokenResponse(response) {
+    const token = {
+      ...response,
+      accessToken: response.access_token,
+      refreshToken: response.refresh_token,
+      expiresAt: buildExpiresAt(response.expires_in ?? 0),
+      refreshExpiresAt: buildExpiresAt(response.refresh_expires_in ?? 0),
+      membership_id: response.membership_id ?? response.membershipId ?? null,
+    };
+    return token;
+  }
+
+  setTokens(tokens) {
+    this.tokens = tokens;
+    persistBungieTokens(tokens);
+    updateBungieState(this.store, {
+      tokens,
+      status: 'ready',
+      membershipId: tokens?.membership_id ?? tokens?.membershipId ?? null,
+    });
+  }
+
+  async getAccessToken() {
+    if (!this.tokens) return null;
+    if (isTokenExpired(this.tokens)) {
+      try {
+        await this.refreshToken();
+      } catch (error) {
+        console.error('Refresh failed', error);
+        this.signOut();
+        throw error;
+      }
+    }
+    return this.tokens.access_token ?? this.tokens.accessToken ?? null;
+  }
+
+  getMembershipId() {
+    return this.tokens?.membership_id ?? this.tokens?.membershipId ?? null;
+  }
+
+  getMembershipType() {
+    return this.tokens?.membership_type ?? this.tokens?.membershipType ?? null;
+  }
+
+  signOut() {
+    this.tokens = null;
+    clearBungieTokens();
+    updateBungieState(this.store, {
+      tokens: null,
+      status: 'idle',
+      membershipId: null,
+      membershipType: null,
+    });
+  }
+}

--- a/beta-docs/bungie-client.js
+++ b/beta-docs/bungie-client.js
@@ -1,0 +1,110 @@
+import { BUNGIE_PLATFORM_URL, getBungieHeaders } from './config.js';
+import { guardArray, guardObject, invariant, toMap } from './utils.js';
+import { updateBungieState } from './state.js';
+
+async function bungieFetch(path, accessToken, options = {}) {
+  const url = path.startsWith('http') ? path : `${BUNGIE_PLATFORM_URL}${path}`;
+  const headers = getBungieHeaders(accessToken);
+  const res = await fetch(url, { ...options, headers });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Bungie request failed: ${res.status} ${text}`);
+  }
+  const data = await res.json();
+  if (data?.ErrorStatus !== 'Success') {
+    throw new Error(`Bungie request error: ${data?.ErrorStatus ?? 'Unknown'}`);
+  }
+  return data.Response;
+}
+
+function pickDestinyMembership(memberships) {
+  const destinyMemberships = guardArray(memberships?.destinyMemberships);
+  if (!destinyMemberships.length) return null;
+  const active = destinyMemberships.find((m) => m.membershipId === memberships?.primaryMembershipId);
+  return active ?? destinyMemberships[0];
+}
+
+export async function loadCurrentProfile(auth, store) {
+  invariant(auth, 'Bungie auth is required');
+  const accessToken = await auth.getAccessToken();
+  if (!accessToken) throw new Error('Bungie access token unavailable');
+
+  updateBungieState(store, { status: 'loading' });
+  const membershipResponse = await bungieFetch('/User/GetMembershipsForCurrentUser/', accessToken);
+  const membership = pickDestinyMembership(membershipResponse);
+  if (!membership) {
+    throw new Error('No Destiny memberships found for this account');
+  }
+
+  updateBungieState(store, {
+    membershipId: membership.membershipId,
+    membershipType: membership.membershipType,
+  });
+
+  const componentParams = new URLSearchParams({
+    components: [
+      'Profiles',
+      'Characters',
+      'CharacterEquipment',
+      'CharacterInventories',
+      'ProfileInventories',
+      'ItemComponents',
+      'ItemInstances',
+      'ItemStats',
+      'ItemObjectives',
+      'CharacterLoadouts',
+    ].join(','),
+  });
+  const profilePath = `/Destiny2/${membership.membershipType}/Profile/${membership.membershipId}/?${componentParams.toString()}`;
+  const profileResponse = await bungieFetch(profilePath, accessToken);
+
+  const profileInventory = guardObject(profileResponse?.profileInventory?.data);
+  const characterInventories = guardObject(profileResponse?.characterInventories?.data);
+  const characterEquipment = guardObject(profileResponse?.characterEquipment?.data);
+  const characters = guardObject(profileResponse?.characters?.data);
+  const itemInstances = guardObject(profileResponse?.itemComponents?.instances?.data);
+  const itemStats = guardObject(profileResponse?.itemComponents?.stats?.data);
+
+  const inventoryItems = [];
+  const pushItems = (bucket) => {
+    for (const item of guardArray(bucket)) {
+      inventoryItems.push(item);
+    }
+  };
+
+  for (const item of guardArray(profileInventory?.items)) pushItems([item]);
+  for (const [characterId, inv] of Object.entries(characterInventories)) {
+    pushItems(inv?.items);
+  }
+  for (const [characterId, equip] of Object.entries(characterEquipment)) {
+    pushItems(equip?.items);
+  }
+
+  const itemsByInstanceId = toMap(inventoryItems, 'itemInstanceId');
+  for (const [instanceId, instance] of Object.entries(itemInstances)) {
+    const existing = itemsByInstanceId.get(instanceId);
+    if (existing) {
+      existing.instance = instance;
+    }
+  }
+  for (const [instanceId, stats] of Object.entries(itemStats)) {
+    const existing = itemsByInstanceId.get(instanceId);
+    if (existing) {
+      existing.stats = stats.stats ?? stats;
+    }
+  }
+
+  const rows = Array.from(itemsByInstanceId.values());
+  updateBungieState(store, {
+    status: 'ready',
+    profile: profileResponse,
+    rawItems: rows,
+    characters,
+  });
+  return {
+    membership,
+    profile: profileResponse,
+    items: rows,
+    characters,
+  };
+}

--- a/beta-docs/config.js
+++ b/beta-docs/config.js
@@ -1,0 +1,112 @@
+const globalConfig = window.D2AA_CONFIG ?? {};
+
+export const STORAGE_KEYS = {
+  rows: 'd2aa-beta-rows',
+  bungieTokens: 'd2aa-beta-bungie-tokens',
+  bungieOAuthState: 'd2aa-beta-bungie-oauth-state',
+  manifest: 'd2aa-beta-manifest',
+  dimTokens: 'd2aa-beta-dim-tokens',
+  dimProfile: 'd2aa-beta-dim-profile-cache',
+};
+
+export const BUNGIE_API_KEY = globalConfig.bungieApiKey ?? '';
+export const BUNGIE_CLIENT_ID = globalConfig.bungieClientId ?? '';
+export const BUNGIE_REDIRECT_URI =
+  globalConfig.bungieRedirectUri ?? `${window.location.origin}${window.location.pathname}`;
+export const BUNGIE_SCOPES = [
+  'ReadBasicUserProfile',
+  'ReadDestinyInventoryAndVault',
+  'ReadDestinyVendorsAndAdvisors',
+  'Destiny2.ReadGroups'
+];
+
+export const BUNGIE_BASE_URL = 'https://www.bungie.net';
+export const BUNGIE_PLATFORM_URL = `${BUNGIE_BASE_URL}/Platform`;
+
+export const DIM_BASE_URL = globalConfig.dimBaseUrl ?? 'https://app.destinyitemmanager.com';
+export const DIM_API_URL = `${DIM_BASE_URL}/api`;
+
+export const DIM_CLIENT_ID = globalConfig.dimClientId ?? '';
+export const DIM_SCOPES = ['dim:profile:read', 'dim:profile:write'];
+
+export const MANIFEST_COMPONENTS = {
+  InventoryItem: 'DestinyInventoryItemDefinition',
+  Stat: 'DestinyStatDefinition',
+  Class: 'DestinyClassDefinition',
+  EnergyType: 'DestinyEnergyTypeDefinition',
+};
+
+export const STAT_MAP = [
+  { id: 2996146975, label: 'Health', short: 'Mobility' },
+  { id: 392767087, label: 'Melee', short: 'Resilience' },
+  { id: 1943323491, label: 'Grenade', short: 'Recovery' },
+  { id: 1735777505, label: 'Super', short: 'Discipline' },
+  { id: 144602215, label: 'Class', short: 'Intellect' },
+  { id: 4244567218, label: 'Weapons', short: 'Strength' },
+];
+
+export const DEFAULT_TOLERANCE = 5;
+
+export const CSV_FILE_HINT = 'Choose DIM Armor.csv';
+
+export const UI_IDS = {
+  fileInput: 'file',
+  uploadTrigger: 'uploadTrigger',
+  uploadHint: 'uploadHint',
+  restoreBtn: 'restoreBtn',
+  clearBtn: 'clearBtn',
+  tolInput: 'tol',
+  rows: 'rows',
+  empty: 'empty',
+  classSeg: 'classSeg',
+  raritySeg: 'raritySeg',
+  slotSeg: 'slotSeg',
+  dupesSeg: 'dupesSeg',
+  themeToggle: 'themeToggle',
+  signInBtn: 'signInWithBungie',
+  statToggle: 'statToggle',
+  appMount: 'app',
+};
+
+export const FILTERS = {
+  classType: ['Any', 'Hunter', 'Titan', 'Warlock'],
+  rarity: ['Any', 'Legendary', 'Exotic'],
+  slot: ['Any', 'Helmet', 'Gauntlets', 'Chest Armor', 'Leg Armor', 'Class Item'],
+  dupes: ['All', 'Only Dupes', 'Hide Dupes'],
+};
+
+export const DIM_TAGS = {
+  favorite: { label: 'Favorite', icon: '★' },
+  keep: { label: 'Keep', icon: '🔒' },
+  infuse: { label: 'Infuse', icon: '⬆️' },
+  junk: { label: 'Junk', icon: '🗑️' },
+};
+
+export function getBungieHeaders(accessToken) {
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+  });
+  if (BUNGIE_API_KEY) headers.set('X-API-Key', BUNGIE_API_KEY);
+  if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`);
+  return headers;
+}
+
+export function buildDimHeaders(accessToken) {
+  const headers = new Headers();
+  headers.set('Content-Type', 'application/json');
+  if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`);
+  return headers;
+}
+
+export function getRequiredConfig() {
+  if (!BUNGIE_CLIENT_ID) {
+    throw new Error('Missing Bungie client id. Configure window.D2AA_CONFIG.bungieClientId before loading the beta script.');
+  }
+  if (!BUNGIE_API_KEY) {
+    console.warn('No Bungie API key configured; manifest and profile requests will likely fail.');
+  }
+  return {
+    BUNGIE_CLIENT_ID,
+    BUNGIE_API_KEY,
+  };
+}

--- a/beta-docs/csv-adapter.js
+++ b/beta-docs/csv-adapter.js
@@ -1,0 +1,34 @@
+import { STAT_MAP } from './config.js';
+import { num, normId } from './utils.js';
+
+function sanitizeRow(row) {
+  const cleaned = { ...row };
+  for (const stat of STAT_MAP) {
+    const baseKey = `${stat.label} (Base)`;
+    const totalKey = `${stat.label} (Total)`;
+    if (cleaned[baseKey] !== undefined) cleaned[baseKey] = num(cleaned[baseKey]);
+    if (cleaned[totalKey] !== undefined) cleaned[totalKey] = num(cleaned[totalKey]);
+  }
+  if (cleaned.Total !== undefined) cleaned.Total = num(cleaned.Total);
+  if (cleaned['Total (Base)'] !== undefined) cleaned['Total (Base)'] = num(cleaned['Total (Base)']);
+  if (cleaned.Id) cleaned.Id = normId(cleaned.Id);
+  return cleaned;
+}
+
+export function parseCsvFile(file) {
+  return new Promise((resolve, reject) => {
+    if (!window.Papa) {
+      reject(new Error('PapaParse is required to parse CSV files'));
+      return;
+    }
+    window.Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (results) => {
+        const data = Array.isArray(results?.data) ? results.data.map(sanitizeRow) : [];
+        resolve(data);
+      },
+      error: (error) => reject(error),
+    });
+  });
+}

--- a/beta-docs/dim-sync.js
+++ b/beta-docs/dim-sync.js
@@ -1,0 +1,109 @@
+import { DIM_API_URL, buildDimHeaders } from './config.js';
+import { buildExpiresAt, isTokenExpired, toMap } from './utils.js';
+import {
+  persistDimTokens,
+  restoreDimTokens,
+  updateDimState,
+} from './state.js';
+
+async function dimFetch(path, token, options = {}) {
+  const url = path.startsWith('http') ? path : `${DIM_API_URL}${path}`;
+  const headers = buildDimHeaders(token?.accessToken ?? token?.access_token);
+  const res = await fetch(url, { ...options, headers });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`DIM request failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+export class DimSync {
+  constructor(store) {
+    this.store = store;
+    this.tokens = restoreDimTokens();
+    if (this.tokens) {
+      updateDimState(store, { status: 'ready', token: this.tokens });
+    }
+  }
+
+  async init(bungieAuth) {
+    if (this.tokens && !isTokenExpired(this.tokens)) {
+      await this.loadAnnotations();
+      return;
+    }
+
+    if (this.tokens && this.tokens.refreshToken) {
+      try {
+        await this.refresh();
+        await this.loadAnnotations();
+        return;
+      } catch (error) {
+        console.warn('DIM token refresh failed', error);
+      }
+    }
+
+    if (!bungieAuth) return;
+    try {
+      await this.authorizeWithBungie(bungieAuth);
+      await this.loadAnnotations();
+    } catch (error) {
+      console.warn('DIM authorization failed', error);
+      updateDimState(this.store, { status: 'error', error: error.message });
+    }
+  }
+
+  async authorizeWithBungie(auth) {
+    const accessToken = await auth.getAccessToken();
+    if (!accessToken) throw new Error('Bungie access token is required for DIM sync');
+    updateDimState(this.store, { status: 'authorizing' });
+    const res = await dimFetch('/auth/bungie', null, {
+      method: 'POST',
+      headers: buildDimHeaders(),
+      body: JSON.stringify({ accessToken }),
+    });
+    this.setTokens(this.normalizeTokens(res));
+  }
+
+  async refresh() {
+    if (!this.tokens?.refreshToken && !this.tokens?.refresh_token) {
+      throw new Error('DIM refresh token unavailable');
+    }
+    updateDimState(this.store, { status: 'refreshing' });
+    const res = await dimFetch('/auth/refresh', null, {
+      method: 'POST',
+      headers: buildDimHeaders(),
+      body: JSON.stringify({ refreshToken: this.tokens.refreshToken ?? this.tokens.refresh_token }),
+    });
+    this.setTokens(this.normalizeTokens(res));
+  }
+
+  normalizeTokens(response) {
+    return {
+      ...response,
+      accessToken: response.accessToken ?? response.access_token,
+      refreshToken: response.refreshToken ?? response.refresh_token,
+      expiresAt: buildExpiresAt(response.expiresIn ?? response.expires_in ?? 0),
+    };
+  }
+
+  setTokens(tokens) {
+    this.tokens = tokens;
+    persistDimTokens(tokens);
+    updateDimState(this.store, { status: 'ready', token: tokens });
+  }
+
+  async loadAnnotations() {
+    if (!this.tokens) return null;
+    updateDimState(this.store, { status: 'loading' });
+    const res = await dimFetch('/profile/items', this.tokens, {
+      method: 'GET',
+    });
+    const items = Array.isArray(res?.items) ? res.items : [];
+    const map = toMap(items, (item) => item.id ?? item.itemInstanceId ?? item.item_id);
+    updateDimState(this.store, {
+      status: 'ready',
+      tagsByInstance: map,
+    });
+    return map;
+  }
+}

--- a/beta-docs/items-adapter.js
+++ b/beta-docs/items-adapter.js
@@ -1,0 +1,89 @@
+import { STAT_MAP } from './config.js';
+import { computeArmorStatsFromCsv, computeArmorStatsFromItem, isArmorItem } from './armor-stats.js';
+import { guardObject, mergeDimTag, normId } from './utils.js';
+
+const CLASS_NAMES = {
+  0: 'Titan',
+  1: 'Hunter',
+  2: 'Warlock',
+};
+
+function resolveClass(definition, manifest) {
+  const classType = definition?.classType;
+  if (classType in CLASS_NAMES) return CLASS_NAMES[classType];
+  const classHash = definition?.classTypeHash;
+  const classDef = manifest?.classDefs?.[classHash];
+  if (classDef?.displayProperties?.name) {
+    return classDef.displayProperties.name;
+  }
+  return 'Unknown';
+}
+
+function resolveSlot(definition) {
+  return definition?.itemTypeDisplayName ?? definition?.inventory?.bucketTypeHash ?? 'Armor';
+}
+
+function resolveTier(definition) {
+  return definition?.inventory?.tierTypeName ?? definition?.inventory?.tierType ?? 'Unknown';
+}
+
+export function adaptBungieItems(items, manifest, dimTags = new Map()) {
+  const defs = manifest?.inventoryItem ?? {};
+  const adapted = [];
+
+  for (const item of items ?? []) {
+    const definition = defs[item.itemHash];
+    if (!isArmorItem(definition)) continue;
+    const stats = computeArmorStatsFromItem(item, manifest);
+    const name = definition?.displayProperties?.name ?? 'Unknown Item';
+    const icon = definition?.displayProperties?.icon;
+    const rarity = resolveTier(definition);
+    const classType = resolveClass(definition, manifest);
+    const slot = resolveSlot(definition);
+
+    const row = {
+      id: normId(item.itemInstanceId ?? `${item.itemHash}`),
+      itemHash: item.itemHash,
+      itemInstanceId: item.itemInstanceId ?? null,
+      name,
+      icon,
+      rarity,
+      classType,
+      slot,
+      tier: rarity,
+      stats,
+      totalBase: stats.totalBase,
+      totalCurrent: stats.totalCurrent,
+      source: 'bungie',
+      rawItem: item,
+      definition,
+    };
+
+    adapted.push(mergeDimTag(row, dimTags));
+  }
+
+  return adapted;
+}
+
+export function adaptCsvRows(rows, dimTags = new Map()) {
+  return (rows ?? []).map((row) => {
+    const stats = computeArmorStatsFromCsv(row);
+    const itemInstanceId = row.Id ? normId(row.Id) : null;
+    const adapted = {
+      id: itemInstanceId ?? row.Id ?? row.Name,
+      itemInstanceId,
+      name: row.Name ?? row.Item ?? 'Unknown Item',
+      icon: row.Icon ?? null,
+      rarity: row.Tier ?? row.Rarity ?? 'Unknown',
+      classType: row.Class ?? row.ClassType ?? 'Unknown',
+      slot: row.Slot ?? row.Bucket ?? row.EquipSlot ?? 'Armor',
+      tier: row.Tier ?? row.Rarity ?? 'Unknown',
+      stats,
+      totalBase: stats.totalBase,
+      totalCurrent: stats.totalCurrent,
+      raw: row,
+      source: 'csv',
+    };
+    return mergeDimTag(adapted, dimTags);
+  });
+}

--- a/beta-docs/manifest.js
+++ b/beta-docs/manifest.js
@@ -1,0 +1,99 @@
+import {
+  BUNGIE_BASE_URL,
+  BUNGIE_PLATFORM_URL,
+  MANIFEST_COMPONENTS,
+  STORAGE_KEYS,
+  getBungieHeaders,
+} from './config.js';
+import { guardObject, safeJsonParse, safeJsonStringify } from './utils.js';
+import { updateManifest } from './state.js';
+
+async function fetchManifestIndex() {
+  const res = await fetch(`${BUNGIE_PLATFORM_URL}/Destiny2/Manifest/`, {
+    headers: getBungieHeaders(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Manifest load failed: ${res.status} ${text}`);
+  }
+  const data = await res.json();
+  if (data?.ErrorStatus !== 'Success') {
+    throw new Error(`Manifest load error: ${data?.ErrorStatus ?? 'Unknown'}`);
+  }
+  return data.Response;
+}
+
+async function fetchDefinitionComponent(path) {
+  const url = `${BUNGIE_BASE_URL}${path}`;
+  const res = await fetch(url, {
+    headers: getBungieHeaders(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Definition fetch failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+function persistManifest(manifest) {
+  try {
+    sessionStorage.setItem(STORAGE_KEYS.manifest, safeJsonStringify(manifest));
+  } catch (error) {
+    console.warn('Unable to persist manifest cache', error);
+  }
+}
+
+function restoreManifest() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEYS.manifest);
+    if (!raw) return null;
+    return safeJsonParse(raw);
+  } catch (error) {
+    console.warn('Unable to restore manifest cache', error);
+    return null;
+  }
+}
+
+export async function loadManifest(store) {
+  const cached = restoreManifest();
+  if (cached) {
+    updateManifest(store, {
+      status: 'ready',
+      lastLoaded: cached.lastLoaded,
+      inventoryItem: cached.inventoryItem ?? {},
+      statDefs: cached.statDefs ?? {},
+      classDefs: cached.classDefs ?? {},
+      energyDefs: cached.energyDefs ?? {},
+    });
+    return cached;
+  }
+
+  updateManifest(store, { status: 'loading' });
+  const index = await fetchManifestIndex();
+  const locale = 'en';
+  const worldPaths = guardObject(index.jsonWorldComponentContentPaths?.Destiny2?.[locale] ?? index.jsonWorldComponentContentPaths?.[locale]);
+  const inventoryPath = worldPaths[MANIFEST_COMPONENTS.InventoryItem];
+  const statPath = worldPaths[MANIFEST_COMPONENTS.Stat];
+  const classPath = worldPaths[MANIFEST_COMPONENTS.Class];
+  const energyPath = worldPaths[MANIFEST_COMPONENTS.EnergyType];
+
+  const [inventoryItem, statDefs, classDefs, energyDefs] = await Promise.all([
+    inventoryPath ? fetchDefinitionComponent(inventoryPath) : {},
+    statPath ? fetchDefinitionComponent(statPath) : {},
+    classPath ? fetchDefinitionComponent(classPath) : {},
+    energyPath ? fetchDefinitionComponent(energyPath) : {},
+  ]);
+
+  const manifest = {
+    status: 'ready',
+    lastLoaded: Date.now(),
+    inventoryItem,
+    statDefs,
+    classDefs,
+    energyDefs,
+  };
+
+  persistManifest(manifest);
+  updateManifest(store, manifest);
+  return manifest;
+}

--- a/beta-docs/state.js
+++ b/beta-docs/state.js
@@ -1,0 +1,244 @@
+import { DEFAULT_TOLERANCE, STORAGE_KEYS } from './config.js';
+import { safeJsonParse, safeJsonStringify } from './utils.js';
+
+const FILTER_DEFAULTS = {
+  classType: 'Any',
+  rarity: 'Any',
+  slot: 'Any',
+  dupes: 'All',
+};
+
+export function createInitialState() {
+  return {
+    source: 'csv',
+    rows: [],
+    tol: DEFAULT_TOLERANCE,
+    filters: { ...FILTER_DEFAULTS },
+    view: 'BASE',
+    manifest: {
+      status: 'idle',
+      lastLoaded: null,
+      inventoryItem: {},
+      statDefs: {},
+      classDefs: {},
+      energyDefs: {},
+    },
+    bungie: {
+      status: 'idle',
+      membershipId: null,
+      membershipType: null,
+      profile: null,
+      characters: [],
+      rawItems: [],
+      tokens: null,
+    },
+    dim: {
+      status: 'idle',
+      token: null,
+      tagsByInstance: new Map(),
+      error: null,
+    },
+    messages: [],
+    ui: {
+      busy: false,
+    },
+  };
+}
+
+export class StateStore {
+  constructor(initialState = createInitialState()) {
+    this.state = initialState;
+    this.listeners = new Set();
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  setState(updater) {
+    const next = typeof updater === 'function' ? updater(this.state) : updater;
+    this.state = { ...this.state, ...next };
+    this.emit();
+  }
+
+  patch(path, value) {
+    const segments = Array.isArray(path) ? path : `${path}`.split('.');
+    const next = structuredClone(this.state);
+    let cursor = next;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const key = segments[i];
+      if (!(key in cursor)) {
+        cursor[key] = {};
+      }
+      cursor = cursor[key];
+    }
+    cursor[segments.at(-1)] = value;
+    this.state = next;
+    this.emit();
+  }
+
+  emit() {
+    for (const listener of this.listeners) {
+      listener(this.state);
+    }
+  }
+}
+
+export function persistRows(rows) {
+  try {
+    localStorage.setItem(STORAGE_KEYS.rows, safeJsonStringify(rows));
+  } catch (error) {
+    console.warn('Unable to persist rows', error);
+  }
+}
+
+export function restoreRows() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.rows);
+    if (!raw) return null;
+    const rows = safeJsonParse(raw);
+    return Array.isArray(rows) ? rows : null;
+  } catch (error) {
+    console.warn('Unable to restore rows', error);
+    return null;
+  }
+}
+
+export function clearRows() {
+  try {
+    localStorage.removeItem(STORAGE_KEYS.rows);
+  } catch (error) {
+    console.warn('Unable to clear saved rows', error);
+  }
+}
+
+export function persistBungieTokens(tokens) {
+  try {
+    sessionStorage.setItem(STORAGE_KEYS.bungieTokens, safeJsonStringify(tokens));
+  } catch (error) {
+    console.warn('Unable to persist Bungie tokens', error);
+  }
+}
+
+export function restoreBungieTokens() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEYS.bungieTokens);
+    if (!raw) return null;
+    const parsed = safeJsonParse(raw);
+    if (!parsed) return null;
+    return parsed;
+  } catch (error) {
+    console.warn('Unable to restore Bungie tokens', error);
+    return null;
+  }
+}
+
+export function clearBungieTokens() {
+  try {
+    sessionStorage.removeItem(STORAGE_KEYS.bungieTokens);
+  } catch (error) {
+    console.warn('Unable to clear Bungie tokens', error);
+  }
+}
+
+export function persistDimTokens(tokens) {
+  try {
+    sessionStorage.setItem(STORAGE_KEYS.dimTokens, safeJsonStringify(tokens));
+  } catch (error) {
+    console.warn('Unable to persist DIM tokens', error);
+  }
+}
+
+export function restoreDimTokens() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEYS.dimTokens);
+    if (!raw) return null;
+    return safeJsonParse(raw);
+  } catch (error) {
+    console.warn('Unable to restore DIM tokens', error);
+    return null;
+  }
+}
+
+export function clearDimTokens() {
+  try {
+    sessionStorage.removeItem(STORAGE_KEYS.dimTokens);
+  } catch (error) {
+    console.warn('Unable to clear DIM tokens', error);
+  }
+}
+
+export function updateManifest(store, manifest) {
+  store.setState((current) => ({
+    manifest: {
+      ...current.manifest,
+      ...manifest,
+      status: manifest?.status ?? current.manifest.status,
+      lastLoaded: manifest?.lastLoaded ?? current.manifest.lastLoaded,
+    },
+  }));
+}
+
+export function updateMessages(store, message) {
+  store.setState((current) => ({
+    messages: message === null ? [] : [...current.messages, message],
+  }));
+}
+
+export function setView(store, view) {
+  store.setState({ view });
+}
+
+export function setTolerance(store, tol) {
+  store.setState({ tol });
+}
+
+export function setRows(store, rows, source = 'csv') {
+  store.setState({ rows, source });
+  persistRows(rows);
+}
+
+export function resetFilters(store) {
+  store.setState({ filters: { ...FILTER_DEFAULTS } });
+}
+
+export function updateFilter(store, key, value) {
+  store.setState((current) => ({
+    filters: {
+      ...current.filters,
+      [key]: value,
+    },
+  }));
+}
+
+export function updateBungieState(store, updater) {
+  store.setState((current) => ({
+    bungie: {
+      ...current.bungie,
+      ...(typeof updater === 'function' ? updater(current.bungie) : updater),
+    },
+  }));
+}
+
+export function updateDimState(store, updater) {
+  store.setState((current) => ({
+    dim: {
+      ...current.dim,
+      ...(typeof updater === 'function' ? updater(current.dim) : updater),
+    },
+  }));
+}
+
+export function setBusy(store, busy) {
+  store.setState((current) => ({
+    ui: {
+      ...current.ui,
+      busy,
+    },
+  }));
+}

--- a/beta-docs/ui-render.js
+++ b/beta-docs/ui-render.js
@@ -1,0 +1,486 @@
+import { CSV_FILE_HINT, FILTERS, STAT_MAP, UI_IDS } from './config.js';
+import {
+  buildDisplayStatList,
+  formatStatTooltip,
+} from './armor-stats.js';
+import {
+  cleanElement,
+  copyTextSafe,
+  statTotals,
+} from './utils.js';
+import { setTolerance, setView, updateFilter } from './state.js';
+
+const THEME_OPTIONS = [
+  { id: 'eclipse', label: 'Eclipse', hint: 'Default' },
+  { id: 'solstice', label: 'Solstice', hint: 'High contrast' },
+  { id: 'dawning', label: 'Dawning', hint: 'Cool blue' },
+];
+const THEME_STORAGE_KEY = 'd2aa-theme';
+
+let storeRef = null;
+let handlersRef = {};
+
+let rowsHost;
+let emptyState;
+let uploadHint;
+let fileInput;
+let signInBtn;
+let tolInput;
+let statToggle;
+let themeContainer;
+const filterElements = {};
+
+function getStoredTheme() {
+  try {
+    return localStorage.getItem(THEME_STORAGE_KEY);
+  } catch (_) {
+    return null;
+  }
+}
+
+function setStoredTheme(value) {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, value);
+  } catch (_) {}
+}
+
+function updateShadowColor(state) {
+  const rarity = state.filters.rarity;
+  const root = document.documentElement;
+  if (rarity === 'Legendary') {
+    root.style.setProperty('--shadow', 'var(--shadow-purple)');
+  } else if (rarity === 'Exotic') {
+    root.style.setProperty('--shadow', 'var(--shadow-gold)');
+  } else {
+    root.style.setProperty('--shadow', 'var(--shadow-base)');
+  }
+}
+
+function applyTheme(themeId, skipStore = false) {
+  const valid = THEME_OPTIONS.some((opt) => opt.id === themeId) ? themeId : THEME_OPTIONS[0].id;
+  document.body.dataset.theme = valid;
+  if (!skipStore) {
+    setStoredTheme(valid);
+  }
+  if (themeContainer) {
+    const buttons = themeContainer.querySelectorAll('[data-theme-option]');
+    buttons.forEach((btn) => {
+      const isActive = btn.dataset.themeOption === valid;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+}
+
+function initThemeToggle(state) {
+  const stored = getStoredTheme();
+  const initial = THEME_OPTIONS.some((opt) => opt.id === stored) ? stored : THEME_OPTIONS[0].id;
+  if (themeContainer) {
+    themeContainer.innerHTML = '';
+    THEME_OPTIONS.forEach((opt) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'theme-toggle__btn';
+      btn.dataset.themeOption = opt.id;
+      btn.setAttribute('aria-pressed', opt.id === initial ? 'true' : 'false');
+      btn.innerHTML = `<span class="theme-toggle__title">${opt.label}</span>` +
+        (opt.hint ? `<span class="theme-toggle__hint">${opt.hint}</span>` : '');
+      btn.addEventListener('click', () => {
+        if (document.body.dataset.theme === opt.id) return;
+        applyTheme(opt.id);
+        updateShadowColor(state);
+      });
+      themeContainer.appendChild(btn);
+    });
+  }
+  applyTheme(initial, true);
+}
+
+function buildSegmentControl(key, values) {
+  const container = filterElements[key];
+  if (!container) return;
+  cleanElement(container);
+  values.forEach((value) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'seg__btn';
+    btn.dataset.value = value;
+    btn.textContent = value;
+    btn.addEventListener('click', () => {
+      updateFilter(storeRef, key, value);
+    });
+    container.appendChild(btn);
+  });
+}
+
+function highlightSegments(state) {
+  Object.entries(filterElements).forEach(([key, container]) => {
+    if (!container) return;
+    const active = state.filters[key];
+    container.querySelectorAll('.seg__btn').forEach((btn) => {
+      const isActive = btn.dataset.value === active;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  });
+}
+
+function buildStatCells(row, view) {
+  const values = buildDisplayStatList(row.stats, view);
+  const frag = document.createDocumentFragment();
+  values.forEach((value) => {
+    const div = document.createElement('div');
+    div.className = 'center';
+    div.textContent = value;
+    frag.appendChild(div);
+  });
+  return frag;
+}
+
+function formatGroupLabel(group) {
+  if (!group?.top3?.length) return '—';
+  return group.top3.map((entry) => entry.name.slice(0, 3).toUpperCase()).join('/');
+}
+
+function rankFromTotals(row) {
+  const total = row.totalBase ?? statTotals(row.stats?.base);
+  if (row.rarity === 'Exotic') {
+    if (total >= 63) return '★★★★★';
+    if (total === 62) return '★★★★☆';
+    if (total === 61) return '★★★☆☆';
+    if (total === 60) return '★★☆☆☆';
+    if (total === 59) return '★☆☆☆☆';
+    return '💩';
+  }
+  if (total >= 75) return '★★★★★';
+  if (total === 74) return '★★★★☆';
+  if (total === 73) return '★★★☆☆';
+  if (total === 72) return '★★☆☆☆';
+  if (total === 71) return '★☆☆☆☆';
+  return '💩';
+}
+
+function computeTop3(stats, view) {
+  const values = buildDisplayStatList(stats, view).map((value, index) => ({
+    id: STAT_MAP[index].id,
+    name: STAT_MAP[index].label,
+    value,
+  }));
+  values.sort((a, b) => (b.value - a.value) || a.name.localeCompare(b.name));
+  return values.slice(0, 3);
+}
+
+function buildGroups(rows, tol, view) {
+  const groups = new Map();
+  for (const row of rows) {
+    const top3 = computeTop3(row.stats, view);
+    const key = [row.classType, row.slot, ...top3.map((entry) => entry.name)].join('|');
+    if (!groups.has(key)) {
+      groups.set(key, { key, items: [], top3 });
+    }
+    const group = groups.get(key);
+    group.items.push({ row, top3, isDupe: false });
+  }
+
+  for (const group of groups.values()) {
+    group.items.forEach((entry) => {
+      const baseTop3 = entry.top3;
+      entry.isDupe = group.items.some((other) => {
+        if (other === entry) return false;
+        return baseTop3.every((stat, index) => {
+          const otherStat = other.top3[index];
+          if (!otherStat) return false;
+          if (otherStat.name !== stat.name) return false;
+          return Math.abs(otherStat.value - stat.value) <= tol;
+        });
+      });
+    });
+  }
+
+  return groups;
+}
+
+function rowMatchesFilters(row, filters) {
+  if (!row) return false;
+  if (filters.classType !== 'Any' && row.classType !== filters.classType) return false;
+  if (filters.rarity !== 'Any' && row.rarity !== filters.rarity) return false;
+  if (filters.slot !== 'Any' && row.slot !== filters.slot) return false;
+  return true;
+}
+
+function filterRows(state) {
+  const { rows, filters } = state;
+  return rows.filter((row) => rowMatchesFilters(row, filters));
+}
+
+function sortRows(rows, view) {
+  const key = view === 'CURRENT' ? 'totalCurrent' : 'totalBase';
+  return [...rows].sort((a, b) => (b[key] ?? 0) - (a[key] ?? 0));
+}
+
+function buildTagCell(row) {
+  const div = document.createElement('div');
+  div.className = 'center';
+  if (row.dimTag) {
+    div.textContent = row.dimTag;
+    div.title = row.dimNotes ?? '';
+  } else {
+    div.textContent = row.raw?.Tag ?? row.raw?.tag ?? '—';
+  }
+  return div;
+}
+
+function buildItemCell(row) {
+  const div = document.createElement('div');
+  const title = document.createElement('div');
+  title.className = 'item-title';
+  title.textContent = row.name;
+  const meta = document.createElement('div');
+  meta.className = 'muted';
+  meta.textContent = `${row.classType} • ${row.slot}`;
+  div.append(title, meta);
+  return div;
+}
+
+function buildTierCell(row) {
+  const div = document.createElement('div');
+  div.className = 'center';
+  div.textContent = row.tier ?? row.rarity ?? '—';
+  return div;
+}
+
+function buildStatsCell(row, view) {
+  const div = document.createElement('div');
+  div.className = 'center stats';
+  div.title = formatStatTooltip(row.stats);
+  buildDisplayStatList(row.stats, view).forEach((value) => {
+    const span = document.createElement('span');
+    span.className = 'stat';
+    span.textContent = value;
+    div.appendChild(span);
+  });
+  return div;
+}
+
+function buildTotalCell(row, view) {
+  const div = document.createElement('div');
+  div.className = 'center';
+  const value = view === 'CURRENT' ? row.totalCurrent : row.totalBase;
+  div.textContent = value ?? '—';
+  return div;
+}
+
+function buildGroupCell(group) {
+  const div = document.createElement('div');
+  div.className = 'center';
+  div.textContent = formatGroupLabel(group);
+  return div;
+}
+
+function buildRankCell(row) {
+  const div = document.createElement('div');
+  div.className = 'center';
+  div.textContent = rankFromTotals(row);
+  return div;
+}
+
+function buildCopyCell(row) {
+  const div = document.createElement('div');
+  div.className = 'right';
+  const button = document.createElement('button');
+  button.className = 'btn';
+  button.textContent = 'Copy id';
+  button.addEventListener('click', async () => {
+    const id = row.itemInstanceId ?? row.id;
+    const ok = await copyTextSafe(`id:${id}`);
+    button.textContent = ok ? 'Copied!' : 'Copy id';
+    window.setTimeout(() => {
+      button.textContent = 'Copy id';
+    }, 1200);
+  });
+  div.appendChild(button);
+  return div;
+}
+
+function buildRow(row, group, isDupe) {
+  const tr = document.createElement('div');
+  tr.className = 'row';
+  if (isDupe) {
+    tr.classList.add('row--dupe');
+  }
+
+  tr.append(
+    buildTagCell(row),
+    buildItemCell(row),
+    buildTierCell(row),
+    buildStatsCell(row, storeRef.getState().view),
+    buildTotalCell(row, storeRef.getState().view),
+    buildGroupCell(group),
+    buildRankCell(row),
+    buildCopyCell(row),
+  );
+
+  return tr;
+}
+
+function renderRows(state) {
+  const filtered = filterRows(state);
+  const sorted = sortRows(filtered, state.view);
+  const groups = buildGroups(sorted, state.tol, 'BASE');
+
+  cleanElement(rowsHost);
+  if (!sorted.length) {
+    emptyState.style.display = 'block';
+    return;
+  }
+  emptyState.style.display = 'none';
+
+  const finalRows = sorted.filter((row) => {
+    const key = [row.classType, row.slot, ...computeTop3(row.stats, 'BASE').map((stat) => stat.name)].join('|');
+    const group = groups.get(key);
+    const entry = group?.items?.find((item) => item.row === row);
+    const isDupe = entry?.isDupe ?? false;
+    if (state.filters.dupes === 'Only Dupes') return isDupe;
+    if (state.filters.dupes === 'Hide Dupes') return !isDupe;
+    return true;
+  });
+
+  if (!finalRows.length) {
+    emptyState.style.display = 'block';
+    return;
+  }
+  emptyState.style.display = 'none';
+
+  finalRows.forEach((row) => {
+    const key = [row.classType, row.slot, ...computeTop3(row.stats, 'BASE').map((stat) => stat.name)].join('|');
+    const group = groups.get(key);
+    const entry = group?.items?.find((item) => item.row === row);
+    const element = buildRow(row, group, entry?.isDupe ?? false);
+    rowsHost.appendChild(element);
+  });
+}
+
+function syncStatToggle(state) {
+  if (!statToggle) return;
+  statToggle.querySelectorAll('button').forEach((button) => {
+    const isActive = button.dataset.view === state.view;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function render(state) {
+  highlightSegments(state);
+  syncStatToggle(state);
+  updateShadowColor(state);
+  if (tolInput) tolInput.value = state.tol;
+  renderRows(state);
+}
+
+function ensureStatToggle() {
+  if (!statToggle) return;
+  cleanElement(statToggle);
+  const baseBtn = document.createElement('button');
+  baseBtn.type = 'button';
+  baseBtn.dataset.view = 'BASE';
+  baseBtn.textContent = 'Base';
+  baseBtn.addEventListener('click', () => setView(storeRef, 'BASE'));
+  const currentBtn = document.createElement('button');
+  currentBtn.type = 'button';
+  currentBtn.dataset.view = 'CURRENT';
+  currentBtn.textContent = 'Current';
+  currentBtn.addEventListener('click', () => setView(storeRef, 'CURRENT'));
+  statToggle.append(baseBtn, currentBtn);
+}
+
+export function initUI(store, handlers = {}) {
+  storeRef = store;
+  handlersRef = handlers;
+
+  rowsHost = document.getElementById(UI_IDS.rows);
+  emptyState = document.getElementById(UI_IDS.empty);
+  uploadHint = document.getElementById(UI_IDS.uploadHint);
+  fileInput = document.getElementById(UI_IDS.fileInput);
+  signInBtn = document.getElementById(UI_IDS.signInBtn);
+  tolInput = document.getElementById(UI_IDS.tolInput);
+  statToggle = document.getElementById(UI_IDS.statToggle);
+  themeContainer = document.getElementById(UI_IDS.themeToggle);
+
+  filterElements.classType = document.getElementById(UI_IDS.classSeg);
+  filterElements.rarity = document.getElementById(UI_IDS.raritySeg);
+  filterElements.slot = document.getElementById(UI_IDS.slotSeg);
+  filterElements.dupes = document.getElementById(UI_IDS.dupesSeg);
+
+  Object.entries(FILTERS).forEach(([key, values]) => buildSegmentControl(key, values));
+  ensureStatToggle();
+  initThemeToggle(store.getState());
+
+  if (fileInput) {
+    fileInput.addEventListener('change', async (event) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      if (handlersRef.onCsvSelected) {
+        handlersRef.onCsvSelected(file);
+      }
+    });
+  }
+
+  const uploadTrigger = document.getElementById(UI_IDS.uploadTrigger);
+  if (uploadTrigger && fileInput) {
+    uploadTrigger.addEventListener('keydown', (evt) => {
+      if (evt.key === 'Enter' || evt.key === ' ') {
+        evt.preventDefault();
+        fileInput.click();
+      }
+    });
+  }
+
+  const restoreBtn = document.getElementById(UI_IDS.restoreBtn);
+  if (restoreBtn) {
+    restoreBtn.addEventListener('click', () => handlersRef.onRestore?.());
+  }
+
+  const clearBtn = document.getElementById(UI_IDS.clearBtn);
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => handlersRef.onClear?.());
+  }
+
+  if (signInBtn) {
+    signInBtn.addEventListener('click', () => handlersRef.onSignIn?.());
+  }
+
+  if (tolInput) {
+    tolInput.addEventListener('input', (event) => {
+      const value = Number(event.target.value);
+      if (!Number.isFinite(value)) return;
+      setTolerance(store, Math.max(0, value));
+    });
+  }
+
+  if (statToggle) {
+    statToggle.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowLeft') setView(store, 'BASE');
+      if (event.key === 'ArrowRight') setView(store, 'CURRENT');
+    });
+  }
+
+  const unsubscribe = store.subscribe(render);
+  render(store.getState());
+
+  return {
+    setUploadHint(text) {
+      if (!uploadHint) return;
+      uploadHint.textContent = text;
+    },
+    resetUploadHint() {
+      if (!uploadHint) return;
+      uploadHint.textContent = uploadHint.dataset.default ?? CSV_FILE_HINT;
+    },
+    clearFileInput() {
+      if (fileInput) fileInput.value = '';
+    },
+    destroy() {
+      unsubscribe();
+    },
+  };
+}

--- a/beta-docs/utils.js
+++ b/beta-docs/utils.js
@@ -1,0 +1,166 @@
+export function num(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function normId(value) {
+  if (typeof value !== 'string') return value;
+  return value.trim().replace(/^id:/i, '');
+}
+
+export function safeJsonParse(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn('JSON parse failed', error);
+    return null;
+  }
+}
+
+export function safeJsonStringify(value) {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    console.warn('JSON stringify failed', error);
+    return 'null';
+  }
+}
+
+export function debounce(fn, wait = 200) {
+  let t;
+  return (...args) => {
+    window.clearTimeout(t);
+    t = window.setTimeout(() => fn(...args), wait);
+  };
+}
+
+export function formatNumber(value) {
+  return Number(value).toLocaleString();
+}
+
+export function buildStatList(stats, order) {
+  return order.map((stat) => stats?.[stat.id] ?? 0);
+}
+
+export function sum(values) {
+  return values.reduce((acc, v) => acc + (Number.isFinite(v) ? v : 0), 0);
+}
+
+export async function copyTextSafe(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (error) {
+    console.warn('Clipboard write failed', error);
+    return false;
+  }
+}
+
+export function guardArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+export function guardObject(value) {
+  return value && typeof value === 'object' ? value : {};
+}
+
+export function pluck(source, path, fallback = null) {
+  if (!source) return fallback;
+  const segments = Array.isArray(path) ? path : `${path}`.split('.');
+  let cursor = source;
+  for (const key of segments) {
+    if (cursor && typeof cursor === 'object' && key in cursor) {
+      cursor = cursor[key];
+    } else {
+      return fallback;
+    }
+  }
+  return cursor ?? fallback;
+}
+
+export function groupBy(list, keyFn) {
+  const map = new Map();
+  for (const item of list ?? []) {
+    const key = keyFn(item);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(item);
+  }
+  return map;
+}
+
+export function isTokenExpired(token) {
+  if (!token) return true;
+  const { expiresAt } = token;
+  if (!expiresAt) return true;
+  return Date.now() >= expiresAt - 15000;
+}
+
+export function buildExpiresAt(seconds) {
+  return Date.now() + seconds * 1000;
+}
+
+export function readSearchParam(name) {
+  const url = new URL(window.location.href);
+  return url.searchParams.get(name);
+}
+
+export function clearSearchParam(name) {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(name)) return;
+  url.searchParams.delete(name);
+  window.history.replaceState({}, document.title, url.toString());
+}
+
+export function toMap(list, key) {
+  const map = new Map();
+  for (const item of list ?? []) {
+    const value = typeof key === 'function' ? key(item) : item?.[key];
+    if (value !== undefined && value !== null) {
+      map.set(String(value), item);
+    }
+  }
+  return map;
+}
+
+export function createBadge(text, title = '') {
+  const span = document.createElement('span');
+  span.className = 'badge';
+  span.textContent = text;
+  if (title) span.title = title;
+  return span;
+}
+
+export function cleanElement(element) {
+  if (!element) return element;
+  while (element.firstChild) element.removeChild(element.firstChild);
+  return element;
+}
+
+export function ensureArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+export function mergeDimTag(row, dimInfo) {
+  if (!row || !dimInfo) return row;
+  const instanceId = row.itemInstanceId ?? row.Id ?? row.id;
+  if (!instanceId) return row;
+  const info = dimInfo.get(String(instanceId));
+  if (!info) return row;
+  return {
+    ...row,
+    dimTag: info.tag ?? null,
+    dimNotes: info.notes ?? '',
+  };
+}
+
+export function statTotals(stats) {
+  return Object.values(stats ?? {}).reduce((acc, value) => acc + (value ?? 0), 0);
+}
+
+export function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/beta.css
+++ b/beta.css
@@ -307,6 +307,22 @@ h1::after {
   position: relative;
 }
 
+.app-status {
+  padding: 8px 10px;
+  border-radius: 16px;
+  border: 1px dashed var(--border);
+  color: var(--sub);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(12, 16, 26, 0.6);
+}
+
 .toolbar__input {
   position: absolute;
   width: 1px;
@@ -343,6 +359,13 @@ h1::after {
   box-shadow: var(--tool-glow);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease, filter 0.2s ease;
   isolation: isolate;
+}
+
+.tool-card.is-disabled,
+.tool-card[disabled] {
+  opacity: 0.6;
+  pointer-events: none;
+  filter: grayscale(0.2);
 }
 
 .tool-card::after {
@@ -434,6 +457,17 @@ button.tool-card {
   --tool-icon-border: rgba(255, 132, 84, 0.4);
   --tool-icon-shadow: inset 0 0 26px rgba(255, 132, 84, 0.28);
   --tool-icon-color: var(--stat-red);
+}
+
+.tool-card--signin {
+  --tool-border: rgba(132, 188, 255, 0.6);
+  --tool-bg: linear-gradient(155deg, rgba(18, 30, 54, 0.94), rgba(12, 18, 32, 0.9));
+  --tool-glow: 0 28px 60px -34px rgba(132, 188, 255, 0.78);
+  --tool-sheen: linear-gradient(155deg, rgba(132, 188, 255, 0.26), rgba(100, 160, 240, 0.16));
+  --tool-icon-bg: radial-gradient(circle at 32% 28%, rgba(132, 188, 255, 0.4), transparent 70%), rgba(8, 16, 30, 0.72);
+  --tool-icon-border: rgba(132, 188, 255, 0.36);
+  --tool-icon-shadow: inset 0 0 26px rgba(132, 188, 255, 0.28);
+  --tool-icon-color: var(--accent);
 }
 
 .tool-icon {

--- a/beta.html
+++ b/beta.html
@@ -64,6 +64,20 @@
               <span class="tool-sub">Remove results</span>
             </span>
           </button>
+          <button class="tool-card tool-card--signin" id="signInWithBungie" type="button" aria-label="Sign in with Bungie">
+            <span class="tool-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 4h16v16H4z" />
+                <path d="M4 9h16" />
+                <path d="M9 4v16" />
+              </svg>
+            </span>
+            <span class="tool-copy">
+              <span class="tool-title">Sign in with Bungie</span>
+              <span class="tool-sub">Load live profile</span>
+            </span>
+          </button>
+          <div id="app" class="app-status" aria-live="polite"></div>
         </div>
       </div>
     </header>
@@ -75,6 +89,7 @@
         <div class="line"><span class="label">Slot</span><div id="slotSeg" class="seg"></div></div>
         <div class="line"><span class="label">Dupes</span><div id="dupesSeg" class="seg"></div></div>
         <div class="line"><span class="label">Tolerance</span><input id="tol" type="number" min="0" max="20" value="5" style="width:80px"/> <span class="muted">± top‑3 stat</span></div>
+        <div class="line"><span class="label">Stats</span><div id="statToggle" class="seg"></div></div>
       </div>
     </section>
 
@@ -103,573 +118,162 @@
     </section>
   </div>
 
-  <script>
-  // ====== Constants ======
-  const STAT_COLS = [
-    "Health (Base)",
-    "Melee (Base)",
-    "Grenade (Base)",
-    "Super (Base)",
-    "Class (Base)",
-    "Weapons (Base)"
-  ];
-  const STAT_ICONS = {
-    "Health (Base)":"https://www.bungie.net/common/destiny2_content/icons/717b8b218cc14325a54869bef21d2964.png",
-    "Melee (Base)":"https://www.bungie.net/common/destiny2_content/icons/fa534aca76d7f2d7e7b4ba4df4271b42.png",
-    "Grenade (Base)":"https://www.bungie.net/common/destiny2_content/icons/065cdaabef560e5808e821cefaeaa22c.png",
-    "Super (Base)":"https://www.bungie.net/common/destiny2_content/icons/585ae4ede9c3da96b34086fccccdc8cd.png",
-    "Class (Base)":"https://www.bungie.net/common/destiny2_content/icons/7eb845acb5b3a4a9b7e0b2f05f5c43f1.png",
-    "Weapons (Base)":"https://www.bungie.net/common/destiny2_content/icons/bc69675acdae9e6b9a68a02fb4d62e07.png"
-  };
-  const RARITY_ICONS = {
-    "Legendary": "https://www.bungie.net/common/destiny2_content/icons/f846f489c2a97afb289b357e431ecf8d.png",
-    "Exotic": "https://www.bungie.net/common/destiny2_content/icons/3e6a698e1a8a5fb446fdcbf1e63c5269.png"
-  };
-  const CLASS_OPTIONS = ["Warlock", "Hunter", "Titan"];
-  const SLOT_OPTIONS = ["All", "Helmet", "Gauntlets", "Chest Armor", "Leg Armor", "Class Item"];
-  const RARITY_OPTIONS = ["All", "Legendary", "Exotic"];  const DUPES_OPTIONS = ["All", "Only Dupes", "Only Same-Name"];
-  const classItemByClass = { Warlock: "Warlock Bond", Hunter: "Hunter Cloak", Titan: "Titan Mark" };
-  const TAG_EMOJIS = {
-    favorite: "❤️",
-    keep: "🏷️",
-    junk: "🚫",
-    infuse: "⚡",
-    archive: "📦"
-  };
-  const TAG_LABELS = {
-    favorite: "Favorite",
-    keep: "Keep",
-    junk: "Junk",
-    infuse: "Infuse",
-    archive: "Archive"
-  };
-  const CLASS_ICONS = {
-    "Warlock": "https://www.bungie.net/common/destiny2_content/icons/e4006d9a8fe167bd7e83193d7601c89a.png",
-    "Hunter":  "https://www.bungie.net/common/destiny2_content/icons/05e32a388d9a65a0ef59b2193eee2db4.png",
-    "Titan":   "https://www.bungie.net/common/destiny2_content/icons/46a19ddd00d0f6ca822230943103b54a.png"
-  };
-  const SLOT_ICONS = {
-    "Helmet": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/helmet.svg",
-    "Gauntlets": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/gloves.svg",
-    "Chest Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/chest.svg",
-    "Leg Armor": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/boots.svg",
-    "Class Item": "https://raw.githubusercontent.com/justrealmilk/destiny-icons/master/armor_types/class.svg"
-  };
-  const ARMOR_ARCHETYPES = {
-    "Grenadier": "https://www.bungie.net/common/destiny2_content/icons/cbf4f03459ab2818a3d37b7362b2aa93.png", // Grenade, Super
-    "Paragon": "https://www.bungie.net/common/destiny2_content/icons/b5feb81f684d767d6212ca138f30b34c.png", // Super, Melee
-    "Specialist": "https://www.bungie.net/common/destiny2_content/icons/69731c603d7bcdd0a21b26c711d55f03.png", // Class, Weapons
-    "Brawler": "https://www.bungie.net/common/destiny2_content/icons/7bc3bc2bccdafc19dde31f867a06ee9f.png", // Melee, Health
-    "Bulwark": "https://www.bungie.net/common/destiny2_content/icons/cda905547dd9eac7a39e6e898f619bc5.png", // Health, Class
-    "Gunner": "https://www.bungie.net/common/destiny2_content/icons/15e3b3c25a6d4606dcb887cb67c915a1.png" // Weapons, Grenade
-  };
+  
+<script type="module">
+  import { StateStore, setRows, restoreRows, clearRows } from './beta-docs/state.js';
+  import { initUI } from './beta-docs/ui-render.js';
+  import { parseCsvFile } from './beta-docs/csv-adapter.js';
+  import { adaptCsvRows, adaptBungieItems } from './beta-docs/items-adapter.js';
+  import { BungieAuth } from './beta-docs/auth-bungie.js';
+  import { loadCurrentProfile } from './beta-docs/bungie-client.js';
+  import { loadManifest } from './beta-docs/manifest.js';
+  import { DimSync } from './beta-docs/dim-sync.js';
+  import { mergeDimTag } from './beta-docs/utils.js';
+  import { BUNGIE_CLIENT_ID } from './beta-docs/config.js';
 
-  const THEME_OPTIONS = [
-    { id: 'eclipse', label: 'Eclipse', hint: 'Shadowfall' },
-    { id: 'solstice', label: 'Solstice', hint: 'Radiant Dawn' },
-    { id: 'nebula', label: 'Nebula', hint: 'Classic Neon' },
-    { id: 'aurora', label: 'Aurora', hint: 'Azure Wake' }
-  ];
-  const THEME_STORAGE_KEY = 'd2aa_theme_v3';
-  const themeContainer = document.getElementById('themeToggle');
+  const store = new StateStore();
+  const auth = new BungieAuth(store);
+  const dimSync = new DimSync(store);
+  const appMount = document.getElementById('app');
+  const signInButton = document.getElementById('signInWithBungie');
 
-  function getStoredTheme() {
-    try {
-      return localStorage.getItem(THEME_STORAGE_KEY);
-    } catch (_) {
-      return null;
-    }
-  }
-
-  function setStoredTheme(value) {
-    try {
-      localStorage.setItem(THEME_STORAGE_KEY, value);
-    } catch (_) {}
-  }
-
-  function applyTheme(themeId, skipStore = false) {
-    const valid = THEME_OPTIONS.some((opt) => opt.id === themeId) ? themeId : THEME_OPTIONS[0].id;
-    document.body.dataset.theme = valid;
-    if (!skipStore) {
-      setStoredTheme(valid);
-    }
-    if (themeContainer) {
-      const buttons = themeContainer.querySelectorAll('[data-theme-option]');
-      buttons.forEach((btn) => {
-        const isActive = btn.dataset.themeOption === valid;
-        btn.classList.toggle('is-active', isActive);
-        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-      });
-    }
-    updateShadowColor();
-  }
-
-  function initThemeToggle() {
-    const stored = getStoredTheme();
-    const initial = THEME_OPTIONS.some((opt) => opt.id === stored) ? stored : THEME_OPTIONS[0].id;
-    if (themeContainer) {
-      themeContainer.innerHTML = '';
-      THEME_OPTIONS.forEach((opt) => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'theme-toggle__btn';
-        btn.dataset.themeOption = opt.id;
-        btn.setAttribute('aria-pressed', opt.id === initial ? 'true' : 'false');
-        btn.innerHTML = `<span class="theme-toggle__title">${opt.label}</span>` +
-          (opt.hint ? `<span class="theme-toggle__hint">${opt.hint}</span>` : '');
-        btn.addEventListener('click', () => {
-          if (document.body.dataset.theme === opt.id) return;
-          applyTheme(opt.id);
-        });
-        themeContainer.appendChild(btn);
-      });
-    }
-    applyTheme(initial, true);
-  }
-  // ====== Helpers ======
-  const normId = (s) => (s ? String(s).trim().replace(/^"|"$/g, "") : "");
-  const normName = (s) => String(s || "").trim().toLowerCase();
-  const num = (v) => (v == null || v === "" ? 0 : Number(v));
-  function slotNumber(type){
-    if(type === "Helmet") return 1;
-    if(type === "Gauntlets") return 2;
-    if(type === "Chest Armor") return 3;
-    if(type === "Leg Armor") return 4;
-    if(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(type)) return 5;
-    return 9;
-  }
-  function starsLegendary(t){ const n=num(t); if(n>=75) return "★★★★★"; if(n===74) return "★★★★☆"; if(n===73) return "★★★☆☆"; if(n===72) return "★★☆☆☆"; if(n===71) return "★☆☆☆☆"; return "💩"; }
-  function starsExotic(t){ const n=num(t); if(n>=63) return "★★★★★"; if(n===62) return "★★★★☆"; if(n===61) return "★★★☆☆"; if(n===60) return "★★☆☆☆"; if(n===59) return "★☆☆☆☆"; return "💩"; }
-  function statColorCls(v){ if(v>=30) return "stat-cyan"; if(v>=24) return "stat-green"; if(v>=15) return "stat-yellow"; return "stat-red"; }
-  function top3Entries(item){
-    const arr = STAT_COLS.map(k => ({ name:k, value:num(item[k]) }));
-    arr.sort((a,b)=> (b.value - a.value) || a.name.localeCompare(b.name));
-    return arr.slice(0,3);
-  }
-  function similarTop3(a,b,tol){
-    const ta = top3Entries(a), tb = top3Entries(b);
-    for(let i=0;i<3;i++){
-      if(ta[i].name !== tb[i].name) return false;
-      if(Math.abs(ta[i].value - tb[i].value) > tol) return false;
-    }
-    return true;
-  }
-  function rankScore(rank){ if(!rank) return -1; const stars=(rank.match(/★/g)||[]).length; if(stars>0) return stars; return 0; }
-  async function copyTextSafe(text){
-    try{
-      if(navigator.clipboard && window.isSecureContext){ await navigator.clipboard.writeText(text); return true; }
-      throw new Error('clipboard api not available');
-    }catch(e){
-      try{ const ta=document.createElement('textarea'); ta.value=text; ta.setAttribute('readonly',''); ta.style.position='fixed'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); const ok=document.execCommand('copy'); document.body.removeChild(ta); return ok; }catch(e2){ alert('Copy failed: '+e2); return false; }
-    }
-  }
-
-  // ====== State & Storage ======
-  let STATE = { 
-    rows:[], 
-    classFilter:'Warlock', 
-    slotFilter:'All', 
-    rarityFilter:'All', 
-    tol:5, 
-    dupesFilter:'All' // NEW
-  };
-  const LS_KEY = 'd2_armor_rows_v1';
-  function saveRows(){ try{ localStorage.setItem(LS_KEY, JSON.stringify(STATE.rows)); }catch(_){} }
-  function loadRows(){ try{ const s=localStorage.getItem(LS_KEY); if(!s) return null; return JSON.parse(s); }catch(_){ return null; } }
-
-  // ====== Filters UI ======
-  function makeSeg(containerId, options, key){
-  const el = document.getElementById(containerId); if(!el) return; el.innerHTML='';
-  options.forEach(opt => {
-    const btn = document.createElement('button');
-    btn.className = 'chip' + (STATE[key]===opt ? ' active' : '');
-    let label = opt;
-    // Add icons for class, rarity, and slot filters
-    if (containerId === 'classSeg' && CLASS_ICONS[opt]) {
-      label = `<span class="chip-icon-mask" style="mask-image:url('${CLASS_ICONS[opt]}');-webkit-mask-image:url('${CLASS_ICONS[opt]}');"></span>${opt}`;
-    }
-    if (containerId === 'raritySeg' && RARITY_ICONS[opt]) {
-      label = `<img src="${RARITY_ICONS[opt]}" alt="${opt}" title="${opt}" class="chip-icon rarity" style="height:1em;vertical-align:middle;margin-right:4px;">${opt}`;
-    }
-    if (containerId === 'slotSeg' && SLOT_ICONS[opt]) {
-      label = `<span class="chip-icon-mask" style="mask-image:url('${SLOT_ICONS[opt]}');-webkit-mask-image:url('${SLOT_ICONS[opt]}');"></span>${opt}`;
-    }
-    btn.innerHTML = (STATE[key]===opt? '● ' : '○ ') + label;
-    btn.addEventListener('click', ()=>{ STATE[key]=opt; render(); makeSeg(containerId, options, key); });
-    el.appendChild(btn);
-  });
-}
-  function initFilters(){
-    makeSeg('classSeg', CLASS_OPTIONS, 'classFilter');
-    makeSeg('raritySeg', RARITY_OPTIONS, 'rarityFilter');
-    makeSeg('slotSeg',   SLOT_OPTIONS,   'slotFilter');
-    makeSeg('dupesSeg',  DUPES_OPTIONS,  'dupesFilter'); // NEW
-  }
-
-  // ====== Data selection ======
-  function getFiltered(){
-  const expected = classItemByClass[STATE.classFilter];
-  // Always group on the full set for dupe logic
-  let baseFiltered = STATE.rows.filter(r =>
-    (STATE.classFilter ? r.Equippable === STATE.classFilter : true) &&
-    (STATE.slotFilter==='All' ? true : STATE.slotFilter==='Class Item' ? r.Type===expected : r.Type===STATE.slotFilter) &&
-    (STATE.rarityFilter==='All' ? true : r.Rarity === STATE.rarityFilter)
-  );
-  // Get all grouped rows for this filtered set
-  const grouped = clusterRows(baseFiltered);
-
-  if (STATE.dupesFilter === "Only Dupes") {
-    // Show only items in any dupe group (Dupe_Group !== "X")
-    return grouped.filter(r => r.Dupe_Group && r.Dupe_Group !== "X");
-  } else if (STATE.dupesFilter === "Only Same-Name") {
-    // Show only dupe groups where all items share the same name
-    // 1. Find all dupe groups
-    const dupeGroups = {};
-    for (const r of grouped) {
-      if (r.Dupe_Group && r.Dupe_Group !== "X") {
-        const key = `${r.GroupKey}::${r.Dupe_Group}`;
-        if (!dupeGroups[key]) dupeGroups[key] = [];
-        dupeGroups[key].push(r);
-      }
-    }
-    // 2. Keep only groups where all items have the same normalized name
-    const validIds = new Set();
-    for (const group of Object.values(dupeGroups)) {
-      const names = new Set(group.map(r => normName(r.Name)));
-      if (names.size === 1) {
-        for (const r of group) validIds.add(r.Id);
-      }
-    }
-    return grouped.filter(r => validIds.has(r.Id));
-  }
-  // Default: show all
-  return grouped;
-}
-
-  // ====== Grouping & Sorting ======
-  function clusterRows(filtered){
-    const byKey = new Map();
-    for(const r of filtered){
-      const k = r.Rarity==='Exotic' ? `${r.Type}|${normName(r.Name)}` : r.Type; // exotics cluster by name
-      if(!byKey.has(k)) byKey.set(k,[]);
-      byKey.get(k).push({...r});
-    }
-    const out=[]; const A='ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    for(const [key,items] of byKey){
-      const assigned = Array(items.length).fill(false);
-      const rawGroups = [];
-      for(let i=0;i<items.length;i++){
-        if(assigned[i]) continue;
-        const grp=[i]; assigned[i]=true;
-        for(let j=i+1;j<items.length;j++){
-          if(assigned[j]) continue;
-          if(STATE.sameNameOnly && normName(items[i].Name)!==normName(items[j].Name)) continue;
-          if(similarTop3(items[i],items[j],STATE.tol)){ grp.push(j); assigned[j]=true; }
-        }
-        rawGroups.push(grp);
-      }
-      // Order groups by best total first, then id to stabilize
-      rawGroups.sort((g1,g2)=>{
-        const best1 = Math.max(...g1.map(ix=>num(items[ix]["Total (Base)"])));
-        const best2 = Math.max(...g2.map(ix=>num(items[ix]["Total (Base)"])));
-        if(best1!==best2) return best2-best1;
-        return String(items[g1[0]].Id).localeCompare(String(items[g2[0]].Id));
-      });
-      const isExoticKey = key.includes('|');
-      let letterIdx = 0;
-      for(const grp of rawGroups){
-        const first = items[grp[0]];
-        let label = 'X';
-        if(grp.length > 1) {
-          const letter = A[Math.min(letterIdx, A.length-1)];
-          if(isExoticKey) {
-            label = `⚠️🟡${slotNumber(first.Type)}${letter}`;
-          } else {
-            label = `⚠️${slotNumber(first.Type)}${letter}`;
-          }
-          letterIdx++;
-        }
-        for(const gi of grp){
-          const it = items[gi];
-          const rank = it.Rarity==='Exotic' ? starsExotic(it["Total (Base)"]) : starsLegendary(it["Total (Base)"]); 
-          out.push({ 
-            ...it, 
-            GroupKey:key, 
-            Dupe_Group:label, 
-            Rank:rank, 
-            RankScore:rankScore(rank), 
-            Is_Dupe: label!=='X',
-            Is_Dupe_Exotic: (it.Rarity==='Exotic' && label!=='X') // <-- Add this flag
-          });
-        }
-      }
-    }
-    // Final sort: 
-out.sort((a, b) => {
-  // 1. Slot order
-  const sa = slotNumber(a.Type), sb = slotNumber(b.Type);
-  if (sa !== sb) return sa - sb;
-
-  // 2. Legendary before Exotic
-  const ra = a.Rarity === "Legendary" ? 0 : 1;
-  const rb = b.Rarity === "Legendary" ? 0 : 1;
-  if (ra !== rb) return ra - rb;
-
-  // 3. Dupe group first within each rarity
-  const da = a.Dupe_Group !== "X";
-  const db = b.Dupe_Group !== "X";
-  if (da !== db) return db - da; // true first
-
-  // 4. For dupe groups: group label, then rank desc, then total desc, then id
-  if (da && db) {
-    // Group by group key (for exotics, this is name+type)
-    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
-    if (a.Dupe_Group !== b.Dupe_Group) return String(a.Dupe_Group).localeCompare(String(b.Dupe_Group));
-    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
-    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
-    if (tb !== ta) return tb - ta;
-    return String(a.Id).localeCompare(String(b.Id));
-  }
-
-  // 5. For exotics: after dupe groups, show non-grouped exotics of same name below groups
-  if (a.Rarity === "Exotic" && b.Rarity === "Exotic") {
-    // GroupKey for exotics is type|name
-    if (a.GroupKey !== b.GroupKey) return String(a.GroupKey).localeCompare(String(b.GroupKey));
-    // Non-grouped exotics of same name (Dupe_Group === "X") come after grouped
-    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
-    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
-    if (tb !== ta) return tb - ta;
-    return String(a.Id).localeCompare(String(b.Id));
-  }
-
-  // 6. For legendaries: non-dupes by name, then rank desc, then total desc, then id
-  if (a.Rarity === "Legendary" && b.Rarity === "Legendary") {
-    const na = String(a.Name).toLowerCase(), nb = String(b.Name).toLowerCase();
-    if (na !== nb) return na.localeCompare(nb);
-    if (b.RankScore !== a.RankScore) return b.RankScore - a.RankScore;
-    const ta = num(a["Total (Base)"]), tb = num(b["Total (Base)"]);
-    if (tb !== ta) return tb - ta;
-    return String(a.Id).localeCompare(String(b.Id));
-  }
-
-  // Fallback: by id
-  return String(a.Id).localeCompare(String(b.Id));
-});
-    return out;
-  }
-
-  // ====== Render ======
-  function render(){
-  updateShadowColor(); 
-    const tolEl=document.getElementById('tol'); if(tolEl) tolEl.value = STATE.tol;
-    initFilters();
-
-    const grouped = getFiltered();
-
-    // Build group->ids for copy-all
-    const groupToIds = new Map();
-    for(const it of grouped){ if(it.Dupe_Group==='X') continue; const key=`${it.GroupKey||''}::${it.Dupe_Group}`; if(!groupToIds.has(key)) groupToIds.set(key,[]); groupToIds.get(key).push(normId(it.Id)); }
-
-    const host=document.getElementById('rows');
-    const empty=document.getElementById('empty');
-    host.innerHTML='';
-    if(grouped.length===0){ if(empty) empty.style.display='block'; return; } else { if(empty) empty.style.display='none'; }
-
-    let lastGroup = null;
-    let altToggle = false;
-    for(const it of grouped){
-      // Alternate shade when group changes (by Dupe_Group label)
-      if (it.Dupe_Group !== lastGroup) {
-        altToggle = !altToggle;
-        lastGroup = it.Dupe_Group;
-      }
-      const row=document.createElement('div');
-      row.className = 'row item ' + (altToggle ? 'altA' : 'altB');
-      // Tag emoji (DIM tag)
-      const cTag = document.createElement('div');
-      cTag.className = 'center';
-      const tag = (it.Tag || '').toLowerCase();
-      cTag.textContent = TAG_EMOJIS[tag] || '';
-      cTag.title = TAG_LABELS[tag] || '';
-      // Item
-      const cItem=document.createElement('div');
-      cItem.innerHTML=`<div style="font-weight:700">${it.Name}</div>
-        <div class="itemmeta">
-          ${(["Warlock Bond","Hunter Cloak","Titan Mark"].includes(it.Type)?"Class Item":it.Type)}
-          • ${it.Equippable}
-          • <img src="${RARITY_ICONS[it.Rarity] || ''}" alt="${it.Rarity}" title="${it.Rarity}" style="height:1em;vertical-align:middle;">
-        </div>
-        <div class="tiny mono">${normId(it.Id)}</div>`;
-      // Tier
-      const cTier=document.createElement('div'); 
-      cTier.className='tier'; 
-      const tVal = Number.isFinite(it.Tier) ? Number(it.Tier) : 0; 
-      cTier.textContent = '♦'.repeat(Math.max(1, Math.min(5, tVal)));
-      // Stats chips
-      const cStats=document.createElement('div'); cStats.className='chips';
-      for(const k of STAT_COLS){
-        const pill=document.createElement('span'); pill.className=`chipStat ${statColorCls(it[k])}`; pill.title=k.replace(' (Base)','');
-        const img=document.createElement('img'); img.className='stat-ico'; img.alt=k; img.src=STAT_ICONS[k]||''; if(img.src) pill.appendChild(img);
-        const strong=document.createElement('strong'); strong.className='mono'; strong.textContent=String(it[k]||0); pill.appendChild(strong);
-        cStats.appendChild(pill);
-      }
-      // Total
-      const cTotal=document.createElement('div'); cTotal.className='center'; cTotal.style.fontWeight='700'; cTotal.textContent=String(it["Total (Base)"]||0);
-      // Group (click to copy all group ids)
-      const cGroup=document.createElement('div'); cGroup.className='center';
-      if(it.Dupe_Group!=='X'){
-        const label = it.Dupe_Group;
-        const key=`${it.GroupKey||''}::${it.Dupe_Group}`;
-        const list=(groupToIds.get(key)||[]).map(id=>`id:${id}`).join(' or ');
-        const span=document.createElement('span'); 
-        span.className='badge-warn'; 
-        span.title='Click to copy all IDs in this dupe group';
-
-        // PATCH: replace 🟡 in label with a rarity <img> for Exotic groups by assembling DOM nodes
-        // We keep label text (which might contain ⚠️🟡1A, etc.) but we render the icon instead of the 🟡
-        // Detect exotic dupe groups using the label pattern OR the item's rarity
-        const exoticGroup = /🟡/.test(label) || it.Rarity === 'Exotic';
-        if (exoticGroup && RARITY_ICONS[it.Rarity]) {
-          // Split off the visible prefix before slot/letter (remove the emoji if present)
-          const textNoYellow = label.replace('🟡','');
-          // Optional: if the label still includes the ⚠️, we keep it in text
-          // Prepend the icon after ⚠️
-          const m = textNoYellow.match(/^(⚠️)?(.*)$/);
-          const prefix = (m && m[1]) ? '⚠️' : '';
-          const rest = (m && m[2]) ? m[2] : textNoYellow;
-          if (prefix) span.append(prefix);
-
-          const img = new Image();
-          img.src = RARITY_ICONS[it.Rarity];
-          img.alt = it.Rarity;
-          img.title = it.Rarity;
-          img.style.height = '1em';
-          img.style.verticalAlign = 'middle';
-          img.style.marginRight = '4px';
-          span.appendChild(img);
-
-          span.append(rest);
-        } else {
-          // Fallback: plain text
-          span.append(label);
-        }
-        span.addEventListener('click', async ()=>{ const ok=await copyTextSafe(list); if(!ok) alert('Copy failed'); });
-        cGroup.appendChild(span);
-      } else {
-        cGroup.innerHTML = `<span class='badge-ok'>✅</span>`;
-      }
-      // Rank
-      const cRank=document.createElement('div'); cRank.className='center'; cRank.textContent=it.Rank||'';
-      // Copy single id
-      const cCopy=document.createElement('div'); cCopy.className='center';
-      const btn=document.createElement('button'); btn.className='btn'; btn.textContent='Copy id';
-      btn.addEventListener('click', async ()=>{ const ok=await copyTextSafe(`id:${normId(it.Id)}`); btn.textContent= ok? 'Copied!' : 'Copy id'; setTimeout(()=> btn.textContent='Copy id', 1200); });
-      cCopy.appendChild(btn);
-
-      row.append(cTag,cItem,cTier,cStats,cTotal,cGroup,cRank,cCopy);
-      host.appendChild(row);
-    }
-  }
-
-  // ====== Events ======
-  const fileInput = document.getElementById('file');
-  const restoreBtn = document.getElementById('restoreBtn');
-  const clearBtn = document.getElementById('clearBtn');
-  const uploadHint = document.getElementById('uploadHint');
-  const uploadTrigger = document.getElementById('uploadTrigger');
-  const uploadHintDefault = uploadHint?.dataset?.default ?? (uploadHint?.textContent ?? 'Choose DIM Armor.csv');
-
-  const setUploadHint = (text) => { if (uploadHint) uploadHint.textContent = text; };
-  const resetUploadHint = () => setUploadHint(uploadHintDefault);
-
-  if (uploadTrigger && fileInput) {
-    uploadTrigger.addEventListener('keydown', (evt) => {
-      if (evt.key === 'Enter' || evt.key === ' ') {
-        evt.preventDefault();
-        fileInput.click();
-      }
-    });
-  }
-
-  if (fileInput) {
-    fileInput.addEventListener('change', (e) => {
-      const f = e.target.files?.[0];
-      if (!f) {
-        resetUploadHint();
-        return;
-      }
-      const fileName = f.name || 'Selected file';
-      setUploadHint(fileName);
-      Papa.parse(f, {
-        header: true,
-        skipEmptyLines: true,
-        complete: (res) => {
-          const data = res.data || [];
-          STATE.rows = data.map((r) => {
-            const x = { ...r };
-            for (const k of [...STAT_COLS, 'Total (Base)', 'Tier']) {
-              if (x[k] !== undefined) {
-                const n = num(x[k]);
-                x[k] = Number.isFinite(n) ? n : 0;
-              }
-            }
-            x.Id = normId(x.Id);
-            return x;
-          });
-          saveRows();
-          render();
-          fileInput.value = '';
-          setUploadHint(`Loaded • ${fileName}`);
-        },
-      });
-    });
-  }
-
-  if (restoreBtn) {
-    restoreBtn.addEventListener('click', () => {
-      const rows = loadRows();
-      if (rows && Array.isArray(rows)) {
-        STATE.rows = rows;
-        render();
-        resetUploadHint();
-      } else {
-        alert('No saved CSV found in this browser. Upload a DIM CSV first.');
-      }
-    });
-  }
-
-  if (clearBtn) {
-    clearBtn.addEventListener('click', () => {
-      STATE.rows = [];
-      localStorage.removeItem(LS_KEY);
-      if (fileInput) fileInput.value = '';
-      render();
-      resetUploadHint();
-    });
-  }
-
-  document.getElementById('tol').addEventListener('input', (e) => {
-    const v = Number(e.target.value);
-    STATE.tol = isFinite(v) ? v : STATE.tol;
-    render();
+  const ui = initUI(store, {
+    onCsvSelected: handleCsvSelected,
+    onRestore: handleRestore,
+    onClear: handleClear,
+    onSignIn: () => auth.startLogin(),
   });
 
-  function updateShadowColor() {
-    const root = document.documentElement;
-    if (STATE.rarityFilter === "Legendary") {
-      root.style.setProperty('--shadow', 'var(--shadow-purple)');
-    } else if (STATE.rarityFilter === "Exotic") {
-      root.style.setProperty('--shadow', 'var(--shadow-gold)');
+  let manifestPromise = null;
+  let lastDimMap = null;
+  let profilePromise = null;
+
+  store.subscribe((state) => {
+    renderAppStatus(state);
+    if (state.dim?.tagsByInstance && state.dim.tagsByInstance !== lastDimMap) {
+      lastDimMap = state.dim.tagsByInstance;
+      applyDimTags();
+    }
+  });
+
+  try {
+    await auth.handleRedirect();
+  } catch (error) {
+    console.error('OAuth redirect handling failed', error);
+  }
+
+  if (!BUNGIE_CLIENT_ID && signInButton) {
+    signInButton.disabled = true;
+    signInButton.classList.add('is-disabled');
+    if (appMount) {
+      appMount.textContent = 'Configure Bungie OAuth in window.D2AA_CONFIG to enable sign-in.';
+    }
+  }
+
+  const cachedRows = restoreRows();
+  if (cachedRows?.length) {
+    setRows(store, cachedRows, 'csv');
+    ui.resetUploadHint();
+  }
+
+  if (auth.tokens && BUNGIE_CLIENT_ID) {
+    bootstrapBungieProfile();
+  }
+
+  async function ensureManifest() {
+    if (!manifestPromise) {
+      manifestPromise = loadManifest(store);
+    }
+    return manifestPromise;
+  }
+
+  async function bootstrapBungieProfile() {
+    if (profilePromise) return profilePromise;
+    profilePromise = (async () => {
+      try {
+        await ensureManifest();
+        await loadCurrentProfile(auth, store);
+        await dimSync.init(auth);
+        applyDimTags();
+        const state = store.getState();
+        const adapted = adaptBungieItems(state.bungie.rawItems, state.manifest, state.dim.tagsByInstance);
+        setRows(store, adapted, 'bungie');
+        ui.setUploadHint('Loaded • Bungie profile');
+      } catch (error) {
+        console.error('Failed to load Bungie profile', error);
+        if (appMount) {
+          appMount.textContent = `Bungie profile failed: ${error.message}`;
+        }
+      }
+    })().finally(() => {
+      profilePromise = null;
+    });
+    return profilePromise;
+  }
+
+  async function handleCsvSelected(file) {
+    try {
+      const rows = await parseCsvFile(file);
+      const state = store.getState();
+      const adapted = adaptCsvRows(rows, state.dim.tagsByInstance);
+      setRows(store, adapted, 'csv');
+      ui.setUploadHint(`Loaded • ${file.name}`);
+    } catch (error) {
+      console.error('CSV parsing failed', error);
+      alert(`Failed to parse CSV: ${error.message}`);
+    } finally {
+      ui.clearFileInput();
+    }
+  }
+
+  function handleRestore() {
+    const rows = restoreRows();
+    if (rows && rows.length) {
+      setRows(store, rows, 'csv');
+      ui.resetUploadHint();
     } else {
-      root.style.setProperty('--shadow', 'var(--shadow-base)');
+      alert('No saved CSV found in this browser. Upload a DIM CSV first.');
     }
   }
 
-  // Initial
-  initThemeToggle();
-  const cached = loadRows(); if(cached){ STATE.rows=cached; }
-  render();
-  updateShadowColor();
+  function handleClear() {
+    setRows(store, [], store.getState().source);
+    clearRows();
+    ui.clearFileInput();
+    ui.resetUploadHint();
+  }
+
+  function applyDimTags() {
+    const state = store.getState();
+    const map = state.dim?.tagsByInstance;
+    if (!map) return;
+    const rowsWithTags = state.rows.map((row) => mergeDimTag(row, map));
+    setRows(store, rowsWithTags, state.source);
+  }
+
+  function renderAppStatus(state) {
+    if (!appMount) return;
+    const parts = [];
+    if (state.bungie?.membershipId) {
+      parts.push(`Signed in: ${state.bungie.membershipId}`);
+    }
+    if (state.source === 'bungie') {
+      parts.push('Data source: Bungie profile');
+    } else if (state.rows.length) {
+      parts.push('Data source: CSV');
+    }
+    if (state.dim?.status === 'ready' && state.dim?.tagsByInstance?.size) {
+      parts.push(`DIM tags: ${state.dim.tagsByInstance.size}`);
+    }
+    appMount.textContent = parts.join(' • ');
+  }
+
+  window.addEventListener('focus', () => {
+    if (auth.tokens && BUNGIE_CLIENT_ID) {
+      bootstrapBungieProfile();
+    }
+  });
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add beta-docs module suite covering config/state/utils, Bungie OAuth/profile loading, DIM sync, stat math, and rendering
- refresh beta.html with a Bungie sign-in control, stats toggle, and module-based entry script that orchestrates CSV fallback, manifest fetch, and DIM tag merging
- update styles for the new toolbar status area and sign-in button

## Testing
- Manual verification by loading beta.html in a local http server

------
https://chatgpt.com/codex/tasks/task_e_68e92f6e6220832d86fe6723e01012b7