### PR TITLE
Enable Bungie item pulls with UI feedback

### DIFF
--- a/beta-docs/config.js
+++ b/beta-docs/config.js
@@ -66,6 +66,7 @@ export const UI_IDS = {
   signInBtn: 'signInWithBungie',
   statToggle: 'statToggle',
   appMount: 'app',
+  actionHeader: 'actionHeader',
 };
 
 export const FILTERS = {

--- a/beta.css
+++ b/beta.css
@@ -561,6 +561,17 @@ button.tool-card {
   transform: translateY(-1px);
 }
 
+.btn:disabled,
+.btn:disabled:hover {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  background: var(--btn-bg);
+  color: rgba(255, 255, 255, 0.55);
+  border-color: var(--btn-border);
+  box-shadow: var(--btn-shadow);
+}
+
 .filters {
   display: flex;
   flex-direction: column;
@@ -1308,4 +1319,55 @@ body[data-theme="solstice"] .tool-card--clear {
   --tool-icon-border: rgba(194, 144, 30, 0.24);
   --tool-icon-shadow: inset 0 0 16px rgba(194, 144, 30, 0.2);
   --tool-icon-color: var(--orange);
+}
+
+.toast-container {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 3000;
+  pointer-events: none;
+}
+
+.toast {
+  min-width: 220px;
+  max-width: 320px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(25, 32, 53, 0.85);
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.4;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: auto;
+}
+
+.toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast--success {
+  border-color: rgba(95, 214, 163, 0.5);
+  background: rgba(23, 48, 42, 0.9);
+  color: #9ff0c6;
+}
+
+.toast--error {
+  border-color: rgba(255, 105, 105, 0.5);
+  background: rgba(56, 21, 21, 0.92);
+  color: #ffbbbb;
+}
+
+.toast--info {
+  border-color: rgba(146, 182, 255, 0.5);
+  background: rgba(27, 36, 62, 0.9);
+  color: #c9dbff;
 }

--- a/beta.html
+++ b/beta.html
@@ -102,7 +102,7 @@
         <div class="center">Total</div>
         <div class="center">Group</div>
         <div class="center">Rank</div>
-        <div class="right">Copy</div>
+        <div class="right" id="actionHeader">Copy ID</div>
       </div>
       <div id="rows"></div>
       <div id="empty" class="empty" style="display:none"><p>
@@ -142,6 +142,7 @@
     onRestore: handleRestore,
     onClear: handleClear,
     onSignIn: () => auth.startLogin(),
+    onPullSuccess: () => bootstrapBungieProfile(),
   });
 
   let manifestPromise = null;


### PR DESCRIPTION
## Summary
- add a Bungie client helper that performs item transfers or postmaster pulls using the stored membership data and token
- update the UI to swap Copy ID for Pull Item actions when Bungie auth is ready, drive the new helper, and surface success/error feedback
- add styling for disabled buttons and toast notifications along with a refresh hook for pull successes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e934dbed58832db9317a586a64f563