### PR TITLE
Update DIM sync to new API endpoints

### DIFF
--- a/beta-docs/README.md
+++ b/beta-docs/README.md
@@ -29,6 +29,11 @@ Before loading `beta.html`, set `window.D2AA_CONFIG` with the Bungie API key and
     bungieClientId: '12345',
     bungieRedirectUri: 'https://your.domain/beta.html',
     dimBaseUrl: 'https://app.destinyitemmanager.com',
+    dimApiEnv: 'prod',
+    dimProdApiUrl: 'https://api.destinyitemmanager.com',
+    dimDevApiUrl: 'https://dev-api.destinyitemmanager.com',
+    dimClientIdProd: 'your-prod-dim-key',
+    dimClientIdDev: 'your-dev-dim-key',
   };
 </script>
 ```

--- a/beta-docs/config.js
+++ b/beta-docs/config.js
@@ -25,9 +25,19 @@ export const BUNGIE_BASE_URL = 'https://www.bungie.net';
 export const BUNGIE_PLATFORM_URL = `${BUNGIE_BASE_URL}/Platform`;
 
 export const DIM_BASE_URL = globalConfig.dimBaseUrl ?? 'https://app.destinyitemmanager.com';
-export const DIM_API_URL = `${DIM_BASE_URL}/api`;
 
-export const DIM_CLIENT_ID = globalConfig.dimClientId ?? '';
+export const DIM_API_ENV = globalConfig.dimApiEnv ?? globalConfig.dimEnvironment ?? 'prod';
+export const DIM_PROD_API_URL = globalConfig.dimProdApiUrl ?? 'https://api.destinyitemmanager.com';
+export const DIM_DEV_API_URL = globalConfig.dimDevApiUrl ?? 'https://dev-api.destinyitemmanager.com';
+export const DIM_API_URL =
+  globalConfig.dimApiUrl ?? (DIM_API_ENV === 'dev' ? DIM_DEV_API_URL : DIM_PROD_API_URL);
+
+export const DIM_CLIENT_ID_PROD = globalConfig.dimClientIdProd ?? globalConfig.dimClientId ?? '';
+export const DIM_CLIENT_ID_DEV = globalConfig.dimClientIdDev ?? '';
+export const DIM_CLIENT_ID =
+  DIM_API_ENV === 'dev'
+    ? DIM_CLIENT_ID_DEV || DIM_CLIENT_ID_PROD
+    : DIM_CLIENT_ID_PROD || DIM_CLIENT_ID_DEV;
 export const DIM_SCOPES = ['dim:profile:read', 'dim:profile:write'];
 
 export const MANIFEST_COMPONENTS = {


### PR DESCRIPTION
## Summary
- point the DIM API configuration at the new hosted endpoints and expose environment-specific overrides
- refactor the DIM sync client to use the updated /auth/token and /profile flows, including refresh handling and tag persistence
- document the new configuration keys in the beta docs README

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e93c4ff010832d881ba5bee5572174