### PR TITLE
Account for socket plugs in armor stat math

### DIFF
--- a/beta-docs/armor-stats.js
+++ b/beta-docs/armor-stats.js
@@ -1,9 +1,95 @@
 import { STAT_MAP } from './config.js';
 import { guardArray, guardObject, num, statTotals } from './utils.js';
 
+const DEBUG_OPTIONS = typeof window !== 'undefined' ? window.D2AA_DEBUG ?? {} : {};
+const DEBUG_ARMOR_STATS = Boolean(DEBUG_OPTIONS.armorStats);
+
+function debugLog(...args) {
+  if (!DEBUG_ARMOR_STATS) return;
+  console.debug('[armor-stats]', ...args);
+}
+
+function accumulateSocketAdjustments(item, manifest) {
+  const socketsComponent = guardObject(item?.sockets ?? item?.socketsComponent);
+  const sockets = guardArray(socketsComponent?.sockets);
+  const inventoryDefs = guardObject(manifest?.inventoryItem);
+  const statDefs = guardObject(manifest?.statDefs);
+
+  const adjustments = {};
+  const debugSockets = [];
+  let masterworkSocketSeen = false;
+  let masterworkStatsApplied = false;
+
+  for (const socket of sockets) {
+    if (socket?.isEnabled === false) continue;
+    const plugHash = socket?.plugHash ?? socket?.plugged?.plugHash;
+    if (!plugHash) continue;
+    const plugDef = inventoryDefs?.[plugHash];
+    if (!plugDef) continue;
+
+    const plugCategory = plugDef?.plug?.plugCategoryIdentifier ?? '';
+    const isArtifice = plugCategory.startsWith('enhancements.artifice');
+    const isMasterwork = plugCategory.includes('masterwork');
+    if (!isArtifice && !isMasterwork) continue;
+
+    if (isMasterwork) {
+      masterworkSocketSeen = true;
+    }
+
+    const investmentStats = guardArray(plugDef?.investmentStats);
+    if (!investmentStats.length) {
+      debugSockets.push({ plugHash, plugCategory, stats: [] });
+      continue;
+    }
+
+    const plugStats = [];
+
+    for (const stat of investmentStats) {
+      const statHash = Number(stat?.statTypeHash);
+      const value = num(stat?.value);
+      if (!Number.isFinite(statHash) || !value) continue;
+      adjustments[statHash] = (adjustments[statHash] ?? 0) + value;
+      plugStats.push({
+        statHash,
+        statName: statDefs?.[statHash]?.displayProperties?.name ?? null,
+        value,
+      });
+      if (isMasterwork) {
+        masterworkStatsApplied = true;
+      }
+    }
+
+    debugSockets.push({ plugHash, plugCategory, stats: plugStats });
+  }
+
+  if (masterworkSocketSeen && !masterworkStatsApplied) {
+    const fallbackStats = [];
+    for (const entry of STAT_MAP) {
+      adjustments[entry.id] = (adjustments[entry.id] ?? 0) + 2;
+      fallbackStats.push({
+        statHash: entry.id,
+        statName: statDefs?.[entry.id]?.displayProperties?.name ?? null,
+        value: 2,
+      });
+    }
+    debugSockets.push({ plugHash: null, plugCategory: 'masterwork-fallback', stats: fallbackStats });
+  }
+
+  return { adjustments, debugSockets };
+}
+
+function buildStatLists(base, current) {
+  return {
+    baseList: STAT_MAP.map((entry) => base?.[entry.id] ?? 0),
+    currentList: STAT_MAP.map((entry) => current?.[entry.id] ?? 0),
+  };
+}
+
 export function computeArmorStatsFromItem(item, manifest) {
   const statsComponent = guardObject(item?.stats ?? item?.statsComponent);
   const dataStats = statsComponent?.data?.stats ?? statsComponent?.stats ?? statsComponent;
+  const { adjustments, debugSockets } = accumulateSocketAdjustments(item, manifest);
+
   const base = {};
   const current = {};
 
@@ -11,17 +97,32 @@ export function computeArmorStatsFromItem(item, manifest) {
     const statHash = Number(stat.statHash ?? stat.stat_id ?? stat.statId);
     const configEntry = STAT_MAP.find((entry) => entry.id === statHash);
     if (!configEntry) continue;
-    const baseValue = num(stat?.investmentValue ?? stat?.base ?? stat?.baseValue ?? stat?.value ?? 0);
-    const totalValue = num(stat?.value ?? stat?.actual ?? baseValue);
+    const totalValue = num(stat?.value ?? stat?.actual ?? stat?.investmentValue ?? stat?.base ?? stat?.baseValue ?? 0);
+    const adjustment = adjustments[statHash] ?? 0;
+    const baseValue = Math.max(0, totalValue - adjustment);
     base[statHash] = baseValue;
     current[statHash] = totalValue;
   }
 
+  const { baseList, currentList } = buildStatLists(base, current);
+  const totalBase = statTotals(base);
+  const totalCurrent = statTotals(current);
+
+  debugLog('computeArmorStatsFromItem', {
+    itemInstanceId: item?.itemInstanceId ?? item?.instanceId ?? item?.id ?? null,
+    adjustments,
+    base,
+    current,
+    sockets: debugSockets,
+  });
+
   return {
     base,
     current,
-    totalBase: statTotals(base),
-    totalCurrent: statTotals(current),
+    baseList,
+    currentList,
+    totalBase,
+    totalCurrent,
   };
 }
 
@@ -31,21 +132,36 @@ export function computeArmorStatsFromCsv(row) {
   for (const stat of STAT_MAP) {
     const baseKey = `${stat.label} (Base)`;
     const totalKey = `${stat.label} (Total)`;
-    base[stat.id] = num(row[`${stat.label} (Base)`] ?? row[stat.label] ?? row[stat.short] ?? 0);
+    const baseValue = Math.max(
+      0,
+      num(row[baseKey] ?? row[stat.label] ?? row[stat.short] ?? 0)
+    );
     const total = row[totalKey] ?? row[`${stat.label} (Current)`];
-    current[stat.id] = num(total, base[stat.id]);
+    base[stat.id] = baseValue;
+    current[stat.id] = num(total, baseValue);
   }
+
+  const { baseList, currentList } = buildStatLists(base, current);
+  const totalBase = statTotals(base);
+  const totalCurrent = statTotals(current);
+
   return {
     base,
     current,
-    totalBase: statTotals(base),
-    totalCurrent: statTotals(current),
+    baseList,
+    currentList,
+    totalBase,
+    totalCurrent,
   };
 }
 
 export function buildDisplayStatList(stats, view = 'BASE') {
-  const source = view === 'CURRENT' ? stats.current : stats.base;
-  return STAT_MAP.map((entry) => source?.[entry.id] ?? 0);
+  if (view === 'CURRENT') {
+    if (Array.isArray(stats?.currentList)) return stats.currentList;
+    return STAT_MAP.map((entry) => stats?.current?.[entry.id] ?? 0);
+  }
+  if (Array.isArray(stats?.baseList)) return stats.baseList;
+  return STAT_MAP.map((entry) => stats?.base?.[entry.id] ?? 0);
 }
 
 export function formatStatTooltip(stats) {

--- a/beta-docs/bungie-client.js
+++ b/beta-docs/bungie-client.js
@@ -52,6 +52,8 @@ export async function loadCurrentProfile(auth, store) {
       'ItemInstances',
       'ItemStats',
       'ItemObjectives',
+      'ItemSockets',
+      'ItemPlugStates',
       'CharacterLoadouts',
     ].join(','),
   });
@@ -64,6 +66,8 @@ export async function loadCurrentProfile(auth, store) {
   const characters = guardObject(profileResponse?.characters?.data);
   const itemInstances = guardObject(profileResponse?.itemComponents?.instances?.data);
   const itemStats = guardObject(profileResponse?.itemComponents?.stats?.data);
+  const itemSockets = guardObject(profileResponse?.itemComponents?.sockets?.data);
+  const itemPlugStates = guardObject(profileResponse?.itemComponents?.plugStates?.data);
 
   const inventoryItems = [];
   const pushItems = (bucket) => {
@@ -91,6 +95,18 @@ export async function loadCurrentProfile(auth, store) {
     const existing = itemsByInstanceId.get(instanceId);
     if (existing) {
       existing.stats = stats.stats ?? stats;
+    }
+  }
+  for (const [instanceId, sockets] of Object.entries(itemSockets)) {
+    const existing = itemsByInstanceId.get(instanceId);
+    if (existing) {
+      existing.sockets = sockets;
+    }
+  }
+  for (const [instanceId, plugState] of Object.entries(itemPlugStates)) {
+    const existing = itemsByInstanceId.get(instanceId);
+    if (existing) {
+      existing.plugStates = plugState;
     }
   }
 


### PR DESCRIPTION
## Summary
- request the ItemSockets and ItemPlugStates components when loading a profile and merge them into each raw item
- derive armor base values by removing masterwork/artifice plug investment stats, clamping results, and exposing base/current stat lists
- add optional debug logging that annotates socket adjustments with manifest stat names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e93ddb8af0832d95288af6d3adace9